### PR TITLE
feat(auth): add json web token verifier (close #5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ build
 .env.production.local
 
 prisma/.env
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1799,6 +1799,15 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
+    "@types/jsonwebtoken": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.5.0.tgz",
+      "integrity": "sha512-9bVao7LvyorRGZCw0VmH/dr7Og+NdjYSsKAxB43OQoComFbBgsEpoR9JW6+qSq/ogwVBg8GI2MfAlk4SYI4OLg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mime": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
@@ -3468,6 +3477,11 @@
         "isarray": "^1.0.0"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -4059,6 +4073,15 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
+    },
+    "cookie-parser": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.5.tgz",
+      "integrity": "sha512-f13bPUj/gG/5mDr+xLmSxxDsB9DQiTIfhJS/sqjrmfAWiAN+x2O4i/XguTL9yDZ+/IFDanJ+5x7hC4CXT9Tdzw==",
+      "requires": {
+        "cookie": "0.4.0",
+        "cookie-signature": "1.0.6"
+      }
     },
     "cookie-signature": {
       "version": "1.0.6",
@@ -5037,6 +5060,14 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -5908,6 +5939,22 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
+        }
+      }
+    },
+    "express-bearer-token": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/express-bearer-token/-/express-bearer-token-2.4.0.tgz",
+      "integrity": "sha512-2+kRZT2xo+pmmvSY7Ma5FzxTJpO3kGaPCEXPbAm3GaoZ/z6FE4K6L7cvs1AUZwY2xkk15PcQw7t4dWjsl5rdJw==",
+      "requires": {
+        "cookie": "^0.3.1",
+        "cookie-parser": "^1.4.4"
+      },
+      "dependencies": {
+        "cookie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         }
       }
     },
@@ -8143,6 +8190,30 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -8161,6 +8232,25 @@
       "requires": {
         "array-includes": "^3.1.1",
         "object.assign": "^4.1.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "killable": {
@@ -8328,10 +8418,45 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "@types/react": "^16.9.45",
     "@types/react-dom": "^16.9.8",
     "express": "^4.17.1",
+    "express-bearer-token": "^2.4.0",
+    "jsonwebtoken": "^8.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-scripts": "^3.4.2",
@@ -44,6 +46,7 @@
   "devDependencies": {
     "@prisma/cli": "^2.4.1",
     "@types/express": "^4.17.7",
+    "@types/jsonwebtoken": "^8.5.0",
     "@types/node": "^14.0.27",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/jest": "^24.9.1",
     "@types/react": "^16.9.45",
     "@types/react-dom": "^16.9.8",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
     "jsonwebtoken": "^8.5.1",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,4 @@
+export const enum ERROR_MSG {
+  NO_TOKEN = '토큰 정보가 존재하지 않습니다.',
+  EXPIRED_TOKEN = '만료된 토큰정보 입니다.',
+}

--- a/src/server/api/index.ts
+++ b/src/server/api/index.ts
@@ -1,8 +1,10 @@
 import express from 'express'
 import { getUserInfoRouter } from './get-user-info'
+import { needToken } from '~/middlewares'
 
 const apiRouter = express.Router()
 
+apiRouter.use(needToken())
 apiRouter.use('/api', getUserInfoRouter)
 
 export { apiRouter }

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -2,9 +2,11 @@ import express from 'express'
 import { apiRouter } from './api'
 import bearerToken from 'express-bearer-token'
 import { tokenVerifier } from './middlewares'
+import dotenv from 'dotenv'
 const app = express()
 const port = 3000
 
+dotenv.config()
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
 app.use(bearerToken())

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,11 +1,14 @@
 import express from 'express'
 import { apiRouter } from './api'
-
+import bearerToken from 'express-bearer-token'
+import { tokenVerifier } from './middlewares'
 const app = express()
 const port = 3000
 
 app.use(express.json())
 app.use(express.urlencoded({ extended: true }))
+app.use(bearerToken())
+app.use(tokenVerifier())
 
 app.use(apiRouter)
 

--- a/src/server/middlewares/index.ts
+++ b/src/server/middlewares/index.ts
@@ -1,10 +1,5 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt from 'jsonwebtoken'
-import dotenv from 'dotenv'
-import path from 'path'
-dotenv.config({
-  path: path.resolve('./prisma/.env'),
-})
 type DecodedData = {
   userId: number
 }

--- a/src/server/middlewares/index.ts
+++ b/src/server/middlewares/index.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt, { TokenExpiredError } from 'jsonwebtoken'
+import { ERROR_MSG } from '~/../constants'
 type DecodedData = {
   userId: number
 }
@@ -7,14 +8,14 @@ export function tokenVerifier() {
   return (req: Request, res: Response, next: NextFunction) => {
     const { token } = req
     try {
-      if (!token) throw new Error('토큰 정보가 존재하지 않습니다.')
+      if (!token) throw new Error(ERROR_MSG.NO_TOKEN)
       const { userId } = jwt.verify(token, process.env.TOKEN_SECRET) as DecodedData
       req.auth = {
         userId,
       }
     } catch (e) {
       if (e instanceof TokenExpiredError) {
-        req.authMessage = '만료된 토큰입니다.'
+        req.authMessage = ERROR_MSG.EXPIRED_TOKEN
         return
       }
       req.authMessage = e.message

--- a/src/server/middlewares/index.ts
+++ b/src/server/middlewares/index.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express'
-import jwt from 'jsonwebtoken'
+import jwt, { TokenExpiredError } from 'jsonwebtoken'
 type DecodedData = {
   userId: number
 }
@@ -7,13 +7,29 @@ export function tokenVerifier() {
   return (req: Request, res: Response, next: NextFunction) => {
     const { token } = req
     try {
-      if (!token) throw new Error()
+      if (!token) throw new Error('토큰 정보가 존재하지 않습니다.')
       const { userId } = jwt.verify(token, process.env.TOKEN_SECRET) as DecodedData
       req.auth = {
         userId,
       }
+    } catch (e) {
+      if (e instanceof TokenExpiredError) {
+        req.authMessage = '만료된 토큰입니다.'
+        return
+      }
+      req.authMessage = e.message
     } finally {
       next()
     }
+  }
+}
+
+export function needToken() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.auth) {
+      next()
+      return
+    }
+    res.status(401).json({ message: req.authMessage }).end()
   }
 }

--- a/src/server/middlewares/index.ts
+++ b/src/server/middlewares/index.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from 'express'
+import jwt from 'jsonwebtoken'
+import dotenv from 'dotenv'
+import path from 'path'
+dotenv.config({
+  path: path.resolve('./prisma/.env'),
+})
+type DecodedData = {
+  userId: number
+}
+export function tokenVerifier() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const { token } = req
+    try {
+      if (!token) throw new Error()
+      const { userId } = jwt.verify(token, process.env.TOKEN_SECRET) as DecodedData
+      req.auth = {
+        userId,
+      }
+    } finally {
+      next()
+    }
+  }
+}

--- a/src/server/types/index.d.ts
+++ b/src/server/types/index.d.ts
@@ -5,3 +5,9 @@ declare namespace Express {
     }
   }
 }
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    TOKEN_SECRET: string
+  }
+}

--- a/src/server/types/index.d.ts
+++ b/src/server/types/index.d.ts
@@ -3,6 +3,7 @@ declare namespace Express {
     auth?: {
       userId: number
     }
+    authMessage: string
   }
 }
 


### PR DESCRIPTION
> prisma/.env파일에 TOKEN_SECRET="DB비밀번호"를 넣어주셔야 합니다!
- 리퀘스트 헤더에 붙은 베어러 토큰을 req.token으로 붙여주는 미들웨어 express-bearer-token 설치
-  process.env.TOKEN_SECRET 타입 추가
- tokenVerifer에서 .env 파일에 담긴 TOKEN_SECRET(DB비밀번호와 동일!) 로 토큰을 검증한 뒤 req.auth에 userId 넣어주기

- dotenv.config() 경로 변경 및 main.ts로 이동
- 빠져있던 dotenv dependency 추가
- 토큰이 invalid한 이유를 담고 있는 authMessage라는 타입을 Request에 추가
- needToken() 미들웨어 추가
- 상수들은 src/constants에서 선언

-resolve #5, resolve #8 