### PR TITLE
feat: add express-validator and request validation middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5985,6 +5985,15 @@
         }
       }
     },
+    "express-validator": {
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-6.6.1.tgz",
+      "integrity": "sha512-+MrZKJ3eGYXkNF9p9Zf7MS7NkPJFg9MDYATU5c80Cf4F62JdLBIjWxy6481tRC0y1NnC9cgOw8FuN364bWaGhA==",
+      "requires": {
+        "lodash": "^4.17.19",
+        "validator": "^13.1.1"
+      }
+    },
     "ext": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
@@ -13760,6 +13769,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.1.1.tgz",
+      "integrity": "sha512-8GfPiwzzRoWTg7OV1zva1KvrSemuMkv07MA9TTl91hfhe+wKrsrgVN4H2QSFd/U/FhiU3iWPYVgvbsOGwhyFWw=="
     },
     "value-equal": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-bearer-token": "^2.4.0",
+    "express-validator": "^6.6.1",
     "jsonwebtoken": "^8.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/server/middlewares/index.ts
+++ b/src/server/middlewares/index.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import jwt, { TokenExpiredError } from 'jsonwebtoken'
-import { ERROR_MSG } from '~/../constants'
+import { ERROR_MSG, STATUS_CODE } from '~/../constants'
+import { validationResult } from 'express-validator'
 type DecodedData = {
   userId: number
 }
@@ -32,5 +33,19 @@ export function needToken() {
       return
     }
     res.status(401).json({ message: req.authMessage }).end()
+  }
+}
+
+export function requestValidator() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const errors = validationResult(req)
+    if (!errors.isEmpty()) {
+      return res.status(STATUS_CODE.BAD_REQUEST).json({
+        message: `${ERROR_MSG.BAD_REQUEST} ${errors
+          .array()
+          .map(({ value, msg, param }) => `${msg} ${value} for ${param}`)}`,
+      })
+    }
+    next()
   }
 }


### PR DESCRIPTION
- add express-validator in project dependencies
- add requestValidator() middleware for processing the resulf of express-validator
- add validator error formatting instead of [Object object]