### PR TITLE
CategoryDetail Refactoring (#81, #83, #80)

### DIFF
--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -12,7 +12,11 @@ export const DrawerContext = createContext<{
   setOpened: DispatchByType<boolean>
 }>(undefined)
 
-const Drawer: React.FC<DrawerProps> = ({ isOpened = true, children, setOpened }) => {
+const Drawer: React.FC<DrawerProps> = ({
+  isOpened = true,
+  children,
+  setOpened,
+}) => {
   const bodyRef = useRef<HTMLDivElement>()
   const backgroundRef = useRef<HTMLDivElement>()
 
@@ -54,21 +58,29 @@ const Drawer: React.FC<DrawerProps> = ({ isOpened = true, children, setOpened })
     <>
       <div
         className="drawer"
-        onMouseMove={({ clientY }) => onCursorMove(clientY, isHolding, startY, bodyRef)}
-        onTouchMove={(event) => onCursorMove(getFirstTouchY(event), isHolding, startY, bodyRef)}
+        onMouseMove={({ clientY }) =>
+          onCursorMove(clientY, isHolding, startY, bodyRef)
+        }
+        onTouchMove={(event) =>
+          onCursorMove(getFirstTouchY(event), isHolding, startY, bodyRef)
+        }
         onMouseUp={({ clientY }) => handleCursorUp(clientY)}
         onTouchEnd={(event) => handleCursorUp(getFirstTouchY(event))}
       >
         <div
           className="background"
           ref={backgroundRef}
-          onClick={() => setOpened && setOpened(false)}
+          onClick={() => setOpened(false)}
         />
         <div className={'body'} ref={bodyRef}>
           <div
             className="holder"
-            onTouchStart={(event) => onCursorDown(getFirstTouchY(event), isHolding, startY)}
-            onMouseDown={({ clientY }) => onCursorDown(clientY, isHolding, startY)}
+            onTouchStart={(event) =>
+              onCursorDown(getFirstTouchY(event), isHolding, startY)
+            }
+            onMouseDown={({ clientY }) =>
+              onCursorDown(clientY, isHolding, startY)
+            }
           >
             <div className="handle" />
           </div>

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, RefObject, useEffect, useRef } from 'react'
-import { DispatchByType } from 'src/pages/CategoryDetails'
 import './style.scss'
 
 export type DrawerProps = {
@@ -8,8 +7,7 @@ export type DrawerProps = {
 }
 
 export const DrawerContext = createContext<{
-  isOpened: boolean
-  setOpened: DispatchByType<boolean>
+  close: () => void
 }>(undefined)
 
 const Drawer: React.FC<DrawerProps> = ({
@@ -85,7 +83,7 @@ const Drawer: React.FC<DrawerProps> = ({
             <div className="handle" />
           </div>
           <div className="container">
-            <DrawerContext.Provider value={{ isOpened, setOpened }}>
+            <DrawerContext.Provider value={{ close: setOpened.bind({}, null) }}>
               {children}
             </DrawerContext.Provider>
           </div>

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -23,7 +23,7 @@ export const STATUS_CODE = {
 export const CONSTRAINT = {
   MAX_ADDRESS_LENGTH: 300,
   MIN_QUANTITY: 1,
-  LONG_PRESS_DURATION = 400,
+  LONG_PRESS_DURATION: 400,
 }
 
 export const PAGINATION = {

--- a/src/pages/CategoryDetails/OptionSelector/index.tsx
+++ b/src/pages/CategoryDetails/OptionSelector/index.tsx
@@ -15,7 +15,7 @@ const OptionSelector: React.FC<OptionSelectorProps> = ({
 }) => {
   const selectRef = useRef<HTMLLIElement>()
   const [optionIdx, setOptionIdx] = useState(0)
-  const setOpened = useContext(DrawerContext)?.setOpened
+  const closeDrawer = useContext(DrawerContext)?.close
 
   useEffect(() => {
     const idx = options.indexOf(option)
@@ -31,7 +31,7 @@ const OptionSelector: React.FC<OptionSelectorProps> = ({
 
   function selectOption() {
     setOption(options[optionIdx])
-    setOpened && setOpened(false)
+    closeDrawer()
   }
 
   return (

--- a/src/pages/CategoryDetails/OptionSelector/index.tsx
+++ b/src/pages/CategoryDetails/OptionSelector/index.tsx
@@ -1,22 +1,38 @@
-import React, { useContext, useEffect, useRef } from 'react'
+import React, { useContext, useEffect, useRef, useState } from 'react'
 import { DrawerContext } from 'src/components/Drawer'
 import './style.scss'
 
 export type OptionSelectorProps = {
   options: string[]
-  optionIdx: number
-  setOptionIdx: (idx: number) => void
+  option?: string
+  setOption: (option: string) => void
 }
 
-export default ({ options = [], optionIdx = 0, setOptionIdx }: OptionSelectorProps) => {
-  const setOpened = useContext(DrawerContext)?.setOpened
+const OptionSelector: React.FC<OptionSelectorProps> = ({
+  options = [],
+  option,
+  setOption,
+}) => {
   const selectRef = useRef<HTMLLIElement>()
+  const [optionIdx, setOptionIdx] = useState(0)
+  const setOpened = useContext(DrawerContext)?.setOpened
 
   useEffect(() => {
-    const height = selectRef.current.getBoundingClientRect().height
+    const idx = options.indexOf(option)
+
+    if (idx !== -1) setOptionIdx(idx)
+  }, [option])
+
+  useEffect(() => {
+    const height = selectRef.current.clientHeight
 
     selectRef.current.style.top = `${height * optionIdx}px`
   }, [optionIdx])
+
+  function selectOption() {
+    setOption(options[optionIdx])
+    setOpened && setOpened(false)
+  }
 
   return (
     <div className="option-selector">
@@ -31,7 +47,7 @@ export default ({ options = [], optionIdx = 0, setOptionIdx }: OptionSelectorPro
               setOptionIdx && setOptionIdx(idx)
             }}
             onPointerUp={() => {
-              if (idx === optionIdx) setOpened && setOpened(false)
+              if (idx === optionIdx) selectOption()
             }}
           >
             {x}
@@ -41,3 +57,5 @@ export default ({ options = [], optionIdx = 0, setOptionIdx }: OptionSelectorPro
     </div>
   )
 }
+
+export default OptionSelector

--- a/src/pages/CategoryDetails/SubCategorySelector/index.tsx
+++ b/src/pages/CategoryDetails/SubCategorySelector/index.tsx
@@ -1,29 +1,33 @@
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { getSubCategories } from 'src/apis'
 import { DEFAULTS } from 'src/constants'
 import { CategoryType } from 'src/types'
-import { CategoryDetailsContext } from '..'
 import './style.scss'
 
 export type SubCategorySelectorProps = {
   category: CategoryType
+  subCategory: string
+  setSubCategory: (subCategory: string) => void
 }
 
 const SubCategorySelector: React.FC<SubCategorySelectorProps> = ({
   category = DEFAULTS.CATEGORY,
+  subCategory,
+  setSubCategory,
 }) => {
   const [subCategories, setSubCategories] = useState([])
-  const { subCategory, setSubCategory } = useContext(CategoryDetailsContext)
 
   useEffect(() => {
     loadSubCategories(category)
   }, [category])
 
-  async function loadSubCategories(category: string) {
-    const newSubCategories = await getSubCategories(category)
+  async function loadSubCategories(newCategory: string) {
+    const newSubCategories = await getSubCategories(newCategory)
 
     setSubCategories(newSubCategories)
-    setSubCategory(newSubCategories[0])
+
+    if (newCategory !== category || !subCategory)
+      setSubCategory(newSubCategories[0])
   }
 
   return (

--- a/src/pages/CategoryDetails/SubCategorySelector/index.tsx
+++ b/src/pages/CategoryDetails/SubCategorySelector/index.tsx
@@ -1,3 +1,4 @@
+import $ from 'classnames'
 import React, { useEffect, useState } from 'react'
 import { getSubCategories } from 'src/apis'
 import { DEFAULTS } from 'src/constants'
@@ -6,28 +7,32 @@ import './style.scss'
 
 export type SubCategorySelectorProps = {
   category: CategoryType
-  subCategory: string
+  subCategory?: string
   setSubCategory: (subCategory: string) => void
 }
 
 const SubCategorySelector: React.FC<SubCategorySelectorProps> = ({
   category = DEFAULTS.CATEGORY,
-  subCategory,
+  subCategory = null,
   setSubCategory,
 }) => {
   const [subCategories, setSubCategories] = useState([])
 
   useEffect(() => {
-    loadSubCategories(category)
+    setSubCategory(null)
+    setSubCategories([])
   }, [category])
 
-  async function loadSubCategories(newCategory: string) {
-    const newSubCategories = await getSubCategories(newCategory)
+  useEffect(() => {
+    loadSubCategories()
+  }, [subCategory])
+
+  async function loadSubCategories() {
+    const newSubCategories = await getSubCategories(category)
 
     setSubCategories(newSubCategories)
 
-    if (newCategory !== category || !subCategory)
-      setSubCategory(newSubCategories[0])
+    if (subCategory === null) setSubCategory(newSubCategories[0])
   }
 
   return (
@@ -35,7 +40,7 @@ const SubCategorySelector: React.FC<SubCategorySelectorProps> = ({
       {subCategories.map((x) => (
         <span
           key={x}
-          className={x === subCategory ? 'active' : null}
+          className={$({ active: x === subCategory })}
           onClick={() => setSubCategory(x)}
         >
           {x}&nbsp;

--- a/src/pages/CategoryDetails/index.tsx
+++ b/src/pages/CategoryDetails/index.tsx
@@ -1,11 +1,4 @@
-import React, {
-  createContext,
-  Dispatch,
-  SetStateAction,
-  useContext,
-  useEffect,
-  useState,
-} from 'react'
+import React, { createContext, Dispatch, SetStateAction, useState } from 'react'
 import Drawer from 'src/components/Drawer'
 import { DEFAULTS } from 'src/constants'
 import { CategoryType, SortByType } from 'src/types'
@@ -28,25 +21,26 @@ export const CategoryDetailsContext = createContext<{
 }>(undefined)
 
 export const CategoryDetailsContextProvider: React.FC = ({ children }) => {
-  const [subCategory, setSubCategory] = useState<CategoryType>(DEFAULTS.CATEGORY)
+  const [subCategory, setSubCategory] = useState<CategoryType>(
+    DEFAULTS.CATEGORY
+  )
   const [sortBy, setSortBy] = useState<SortByType>(DEFAULTS.OPTION)
 
   return (
-    <CategoryDetailsContext.Provider value={{ subCategory, setSubCategory, sortBy, setSortBy }}>
+    <CategoryDetailsContext.Provider
+      value={{ subCategory, setSubCategory, sortBy, setSortBy }}
+    >
       {children}
     </CategoryDetailsContext.Provider>
   )
 }
 
-export const CombineProvider = (...Providers: React.FC[]) => (App: React.FC) =>
-  Providers.reduce((acc, Provider) => <Provider>{acc}</Provider>, <App />)
-
-const CategoryDetails: React.FC<CategoryDetailsProps> = ({ category = DEFAULTS.CATEGORY }) => {
-  const { subCategory } = useContext(CategoryDetailsContext)
+const CategoryDetails: React.FC<CategoryDetailsProps> = ({
+  category = DEFAULTS.CATEGORY,
+}) => {
   const [isOpened, setOpened] = useState(false)
-  const [optionIdx, setOptionIdx] = useState(0)
-
-  useEffect(() => {}, [subCategory])
+  const [sortBy, setSortBy] = useState<string>(DEFAULTS.OPTION)
+  const [subCategory, setSubCategory] = useState(null)
 
   return (
     <div className="category-details">
@@ -54,26 +48,23 @@ const CategoryDetails: React.FC<CategoryDetailsProps> = ({ category = DEFAULTS.C
         {category}
         <div className="title-icon" />
       </div>
-      <SubCategorySelector category={category} />
+      <SubCategorySelector
+        category={category}
+        subCategory={subCategory}
+        setSubCategory={setSubCategory}
+      />
       <div className="sort-by" onClick={() => setOpened(true)}>
         <div className="sort-by-icon"></div>
-        {DEFAULTS.SORT_OPTIONS[optionIdx]}
+        {sortBy}
       </div>
       <Drawer isOpened={isOpened} setOpened={setOpened}>
         <OptionSelector
           options={DEFAULTS.SORT_OPTIONS.slice()}
-          optionIdx={optionIdx}
-          setOptionIdx={setOptionIdx}
+          setOption={setSortBy}
         ></OptionSelector>
       </Drawer>
     </div>
   )
 }
 
-export default (props: CategoryDetailsProps) => {
-  return (
-    <CategoryDetailsContextProvider>
-      <CategoryDetails {...props}></CategoryDetails>
-    </CategoryDetailsContextProvider>
-  )
-}
+export default CategoryDetails

--- a/src/pages/CategoryDetails/index.tsx
+++ b/src/pages/CategoryDetails/index.tsx
@@ -20,21 +20,6 @@ export const CategoryDetailsContext = createContext<{
   setSortBy: DispatchByType<SortByType>
 }>(undefined)
 
-export const CategoryDetailsContextProvider: React.FC = ({ children }) => {
-  const [subCategory, setSubCategory] = useState<CategoryType>(
-    DEFAULTS.CATEGORY
-  )
-  const [sortBy, setSortBy] = useState<SortByType>(DEFAULTS.OPTION)
-
-  return (
-    <CategoryDetailsContext.Provider
-      value={{ subCategory, setSubCategory, sortBy, setSortBy }}
-    >
-      {children}
-    </CategoryDetailsContext.Provider>
-  )
-}
-
 const CategoryDetails: React.FC<CategoryDetailsProps> = ({
   category = DEFAULTS.CATEGORY,
 }) => {

--- a/src/pages/CategoryDetails/index.tsx
+++ b/src/pages/CategoryDetails/index.tsx
@@ -19,7 +19,7 @@ export const CategoryDetailsContext = createContext<{
   setSubCategory: DispatchByType<string>
   setSortBy: DispatchByType<SortByType>
 }>(undefined)
-type DrawerType = 'category' | 'sortBy' | null
+type DrawerType = 'sortBy' | 'category' | null
 
 const CategoryDetails: React.FC<CategoryDetailsProps> = ({
   category = DEFAULTS.CATEGORY,
@@ -30,8 +30,8 @@ const CategoryDetails: React.FC<CategoryDetailsProps> = ({
   const [subCategory, setSubCategory] = useState(null)
 
   return (
-    <div className="category-details" onClick={() => openDrawer('category')}>
-      <div className="title">
+    <div className="category-details">
+      <div className="title" onClick={() => openDrawer('category')}>
         {category}
         <div className="title-icon" />
       </div>

--- a/src/pages/CategoryDetails/index.tsx
+++ b/src/pages/CategoryDetails/index.tsx
@@ -19,16 +19,18 @@ export const CategoryDetailsContext = createContext<{
   setSubCategory: DispatchByType<string>
   setSortBy: DispatchByType<SortByType>
 }>(undefined)
+type DrawerType = 'category' | 'sortBy' | null
 
 const CategoryDetails: React.FC<CategoryDetailsProps> = ({
   category = DEFAULTS.CATEGORY,
+  setCategory,
 }) => {
-  const [isOpened, setOpened] = useState(false)
+  const [drawerType, openDrawer] = useState<DrawerType>(null)
   const [sortBy, setSortBy] = useState<string>(DEFAULTS.OPTION)
   const [subCategory, setSubCategory] = useState(null)
 
   return (
-    <div className="category-details">
+    <div className="category-details" onClick={() => openDrawer('category')}>
       <div className="title">
         {category}
         <div className="title-icon" />
@@ -38,14 +40,18 @@ const CategoryDetails: React.FC<CategoryDetailsProps> = ({
         subCategory={subCategory}
         setSubCategory={setSubCategory}
       />
-      <div className="sort-by" onClick={() => setOpened(true)}>
+      <div className="sort-by" onClick={() => openDrawer('sortBy')}>
         <div className="sort-by-icon"></div>
         {sortBy}
       </div>
-      <Drawer isOpened={isOpened} setOpened={setOpened}>
+      <Drawer isOpened={drawerType !== null} setOpened={() => openDrawer(null)}>
         <OptionSelector
-          options={DEFAULTS.SORT_OPTIONS.slice()}
-          setOption={setSortBy}
+          options={
+            drawerType === 'category'
+              ? DEFAULTS.CATEGORIES.slice()
+              : DEFAULTS.SORT_OPTIONS.slice()
+          }
+          setOption={drawerType === 'category' ? setCategory : setSortBy}
         ></OptionSelector>
       </Drawer>
     </div>

--- a/src/stories/DiscountLabel.stories.tsx
+++ b/src/stories/DiscountLabel.stories.tsx
@@ -7,6 +7,8 @@ export default {
   component: DiscountLabel,
 } as Meta
 
-const Template: Story<DiscountLabelProps> = (args) => <DiscountLabel {...args} />
+const Template: Story<DiscountLabelProps> = (args) => (
+  <DiscountLabel {...args} />
+)
 
 export const DiscountLabelTest = Template.bind({})

--- a/src/stories/Drawer.stories.tsx
+++ b/src/stories/Drawer.stories.tsx
@@ -52,13 +52,13 @@ const OptionsDrawerTemplate: Story<DrawerProps> = (args) => {
   useEffect(() => {
     setOpened(args.isOpened)
   }, [args.isOpened])
-  const [optionIdx, setOptionIdx] = useState(0)
+  const [option, setOption] = useState(null)
 
   return (
     <Drawer isOpened={isOpened} setOpened={setOpened}>
       <OptionSelector
-        optionIdx={optionIdx}
-        setOptionIdx={setOptionIdx}
+        option={option}
+        setOption={setOption}
         options={Array.from({ length: 30 }, (_, i) => String(i))}
       ></OptionSelector>
     </Drawer>
@@ -68,7 +68,7 @@ const OptionsDrawerTemplate: Story<DrawerProps> = (args) => {
 export const withOptionSelectors = OptionsDrawerTemplate.bind({})
 
 const SortOptionsDrawerTemplate: Story<DrawerProps> = (args) => {
-  const [optionIdx, setOptionIdx] = useState(0)
+  const [option, setOption] = useState(null)
   const [isOpened, setOpened] = useState(false)
 
   useEffect(() => {
@@ -78,8 +78,8 @@ const SortOptionsDrawerTemplate: Story<DrawerProps> = (args) => {
   return (
     <Drawer isOpened={isOpened} setOpened={setOpened}>
       <OptionSelector
-        optionIdx={optionIdx}
-        setOptionIdx={setOptionIdx}
+        option={option}
+        setOption={setOption}
         options={DEFAULTS.SORT_OPTIONS.slice()}
       ></OptionSelector>
     </Drawer>

--- a/src/stories/OptionSelector.stories.tsx
+++ b/src/stories/OptionSelector.stories.tsx
@@ -13,16 +13,6 @@ export default {
     options: DEFAULTS.SORT_OPTIONS.slice(),
     option: null,
   },
-  argTypes: {
-    optionIdx: {
-      control: {
-        type: 'range',
-        min: 0,
-        max: DEFAULTS.SORT_OPTIONS.length - 1,
-        step: 1,
-      },
-    },
-  },
 } as Meta
 
 const Template: Story<OptionSelectorProps> = (args) => {

--- a/src/stories/OptionSelector.stories.tsx
+++ b/src/stories/OptionSelector.stories.tsx
@@ -1,23 +1,34 @@
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Meta, Story } from '@storybook/react/types-6-0'
-import React from 'react'
+import React, { useState } from 'react'
 import { DEFAULTS } from 'src/constants'
-import OptionSelector, { OptionSelectorProps } from '../pages/CategoryDetails/OptionSelector'
+import OptionSelector, {
+  OptionSelectorProps,
+} from '../pages/CategoryDetails/OptionSelector'
 
 export default {
   title: 'CategoryDetails/OptionSelector',
   component: OptionSelector,
   args: {
     options: DEFAULTS.SORT_OPTIONS.slice(),
-    optionIdx: 0,
+    option: null,
   },
   argTypes: {
     optionIdx: {
-      control: { type: 'range', min: 0, max: DEFAULTS.SORT_OPTIONS.length - 1, step: 1 },
+      control: {
+        type: 'range',
+        min: 0,
+        max: DEFAULTS.SORT_OPTIONS.length - 1,
+        step: 1,
+      },
     },
   },
 } as Meta
 
-const Template: Story<OptionSelectorProps> = (args) => <OptionSelector {...args} />
+const Template: Story<OptionSelectorProps> = (args) => {
+  const [option, setOption] = useState(args.option)
+
+  return <OptionSelector {...args} option={option} setOption={setOption} />
+}
 
 export const Main = Template.bind({})

--- a/src/stories/SubCategorySelector.stories.tsx
+++ b/src/stories/SubCategorySelector.stories.tsx
@@ -1,8 +1,7 @@
 // also exported from '@storybook/react' if you can deal with breaking changes in 6.1
 import { Meta, Story } from '@storybook/react/types-6-0'
-import React from 'react'
+import React, { useState } from 'react'
 import { DEFAULTS } from 'src/constants'
-import { CategoryDetailsContextProvider } from 'src/pages/CategoryDetails'
 import SubCategorySelector, {
   SubCategorySelectorProps,
 } from 'src/pages/CategoryDetails/SubCategorySelector'
@@ -24,10 +23,14 @@ export default {
 } as Meta
 
 const Template: Story<SubCategorySelectorProps> = (args) => {
+  const [subCategory, setSubCategory] = useState(null)
+
   return (
-    <CategoryDetailsContextProvider>
-      <SubCategorySelector {...args}></SubCategorySelector>
-    </CategoryDetailsContextProvider>
+    <SubCategorySelector
+      {...args}
+      subCategory={subCategory}
+      setSubCategory={setSubCategory}
+    ></SubCategorySelector>
   )
 }
 


### PR DESCRIPTION
### OptionSelector에서 props에서 optionIdx가 아니라 option으로 props 넘겨주기
- Selector끼리 일관적인 props를 가지기 위해서...
- this closes #81
### CategoryDetails에서 불필요한 Context 없애기
- CategoryDetails와 OptionSelector, SubCategorySelector 사이에 Context로 상태를 공유하고 있었는데 props로 전달받기
- this closes #83 
### 카테고리도 선택가능하게 기능 추가
- this closes #80