### PR TITLE
Drawer fast

### DIFF
--- a/src/components/Drawer/style.scss
+++ b/src/components/Drawer/style.scss
@@ -1,6 +1,4 @@
 .drawer {
-  $drawerHeight: 20px;
-
   .background {
     position: fixed;
     top: 0;
@@ -46,6 +44,7 @@
     .container {
       max-height: 70vh;
       overflow: scroll;
+      will-change: scroll-position;
     }
   }
 }

--- a/src/pages/CategoryDetails/OptionSelector/index.tsx
+++ b/src/pages/CategoryDetails/OptionSelector/index.tsx
@@ -15,23 +15,27 @@ const OptionSelector: React.FC<OptionSelectorProps> = ({
 }) => {
   const selectRef = useRef<HTMLLIElement>()
   const [optionIdx, setOptionIdx] = useState(0)
-  const closeDrawer = useContext(DrawerContext)?.close
+  const { isOpened, closeDrawer, setFocusPosition } =
+    useContext(DrawerContext) ?? {}
 
   useEffect(() => {
     const idx = options.indexOf(option)
 
-    if (idx !== -1) setOptionIdx(idx)
-  }, [option])
+    if (idx !== -1) {
+      setOptionIdx(idx)
+      setFocusPosition(selectRef.current.clientHeight * idx)
+    }
+  }, [option, isOpened])
 
   useEffect(() => {
-    const height = selectRef.current.clientHeight
+    const top = selectRef.current.clientHeight * optionIdx
 
-    selectRef.current.style.top = `${height * optionIdx}px`
+    selectRef.current.style.transform = `translatey(${top}px)`
   }, [optionIdx])
 
   function selectOption() {
     setOption(options[optionIdx])
-    closeDrawer()
+    closeDrawer && closeDrawer()
   }
 
   return (


### PR DESCRIPTION
### Drawer
- bottom을 transition하던 것을 translate로 변경
- drawer를 열고 닫을 때 마다 선택된 항목으로 자동으로 스크롤이 되도록 isOpened, setFocusPosition을 자식에게 컨텍스트로 넘겨줌 (자식은 드로우가 언제 열리고 닫혔나를 알아야 함)

### OptionSelector
- selectRef is animated by translateY not top …
- 드로어가 열고 닫힐 때 마다 포커스될 위치를 부모에게 전달해줌