### PR TITLE
refactor: convert SearchResults into ProductContainer

### DIFF
--- a/src/components/ProductContainer/index.tsx
+++ b/src/components/ProductContainer/index.tsx
@@ -5,17 +5,17 @@ import { ProductWithJjimmed } from 'src/types/api'
 import { getItemNumbersInRow, getRowNumber } from 'src/utils'
 import './style.scss'
 
-export type SearchResultsProps = {
+export type ProductContainerProps = {
   isSkeletonOn: boolean
-  results: (Product | ProductWithJjimmed)[]
+  products: (Product | ProductWithJjimmed)[]
   onLoadMore: () => void
 }
 
 let previousIntersectingStatus
 
-const SearchResults: React.FC<SearchResultsProps> = ({
+const ProductContainer: React.FC<ProductContainerProps> = ({
   isSkeletonOn,
-  results,
+  products,
   onLoadMore,
 }) => {
   const gridRef = useRef<HTMLDivElement>()
@@ -48,19 +48,19 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   }, [isSkeletonOn])
 
   return (
-    <div className="search-results" ref={gridRef}>
+    <div className="product-container" ref={gridRef}>
       {isSkeletonOn
         ? Array(8)
             .fill(undefined)
             .map((_, idx) => (
-              <div key={idx} className="search-results-result">
+              <div key={idx} className="product-container-product">
                 <ProductItem isSkeleton={true} />
               </div>
             ))
-        : results.map((result, idx) => (
+        : products.map((result, idx) => (
             <div
               key={result.id}
-              className="search-results-result"
+              className="product-container-product"
               style={{
                 animationDelay: `${getRowNumber(idx, itemNumsInRow) * 200}ms`,
               }}
@@ -73,4 +73,4 @@ const SearchResults: React.FC<SearchResultsProps> = ({
   )
 }
 
-export default SearchResults
+export default ProductContainer

--- a/src/components/ProductContainer/style.scss
+++ b/src/components/ProductContainer/style.scss
@@ -1,6 +1,6 @@
 @use '~src/styles/design-system' as *;
 
-.search-results {
+.product-container {
   @include grid-template();
 
   position: relative;

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { search } from 'src/apis'
+import ProductContainer from 'src/components/ProductContainer'
 import SearchInputContainer from './SearchInputContainer'
-import SearchResults from './SearchResults'
 import SearchTerms from './SearchTerms'
 import './style.scss'
 
@@ -120,9 +120,9 @@ const Search: React.FC<SearchProps> = () => {
           }}
         />
       ) : (
-        <SearchResults
+        <ProductContainer
           isSkeletonOn={isSkeletonOn}
-          results={foundProducts}
+          products={foundProducts}
           onLoadMore={onLoadMore}
         />
       )}


### PR DESCRIPTION
## SearchResults => ProductContainer 
다른 컴포넌트에서 공유할 수 있는 컴포넌트이므로 파일명, 파일 위치 변경

Props
- isSkeletonOn: boolean
- products: (Product | ProductWithJjimmed)[]
- onLoadMore: () => void

아직 무한스크롤 구현되지 않았음