### PR TITLE
OAuth Login using passport and jwt

### DIFF
--- a/craco.config.js
+++ b/craco.config.js
@@ -1,7 +1,12 @@
 const eslintConfig = require('./.eslintrc.js')
-
 module.exports = {
   eslint: {
     configure: eslintConfig,
+  },
+  devServer: {
+    proxy: {
+      '/api': 'http://localhost:13100',
+      '/auth': 'http://localhost:13100',
+    },
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5144,6 +5144,15 @@
       "integrity": "sha512-4QQmOF5KlwfxJ5IGXFIudkeLCdMABz03RcUXu+LCb24zmln8QW6aDjuGl4d4XPVLf2j+FnjelHTP7dvceAFbhA==",
       "dev": true
     },
+    "@types/oauth": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@types/oauth/-/oauth-0.9.1.tgz",
+      "integrity": "sha512-a1iY62/a3yhZ7qH7cNUsxoI3U/0Fe9+RnuFrpTKr+0WVOzbKlSLojShCKe20aOD1Sppv+i8Zlq0pLDuTJnwS4A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/overlayscrollbars": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/@types/overlayscrollbars/-/overlayscrollbars-1.12.0.tgz",
@@ -5160,6 +5169,37 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-5.0.3.tgz",
       "integrity": "sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==",
       "dev": true
+    },
+    "@types/passport": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.4.tgz",
+      "integrity": "sha512-h5OfAbfBBYSzjeU0GTuuqYEk9McTgWeGQql9g3gUw2/NNCfD7VgExVRYJVVeU13Twn202Mvk9BT0bUrl30sEgA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/passport-github": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/passport-github/-/passport-github-1.1.5.tgz",
+      "integrity": "sha512-BeWDdLRWfPpJcmT1XofY5r1Av//TcxBEgllY4LnArcYdGqbIIVLyHwR+8bIG+ZC4PwJ6W1trnVEG3EQ+5J+Jmw==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/passport": "*",
+        "@types/passport-oauth2": "*"
+      }
+    },
+    "@types/passport-oauth2": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/passport-oauth2/-/passport-oauth2-1.4.9.tgz",
+      "integrity": "sha512-QP0q+NVQOaIu2r0e10QWkiUA0Ya5mOBHRJN0UrI+LolMLOP1/VN4EVIpJ3xVwFo+xqNFRoFvFwJhBvKnk7kpUA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*",
+        "@types/oauth": "*",
+        "@types/passport": "*"
+      }
     },
     "@types/prop-types": {
       "version": "15.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7206,6 +7206,11 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
+    "base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
+    },
     "basic-auth": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
@@ -14653,6 +14658,11 @@
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
       "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ=="
     },
+    "oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
+    },
     "oauth-sign": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
@@ -15070,6 +15080,40 @@
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
       "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
     },
+    "passport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.4.1.tgz",
+      "integrity": "sha512-IxXgZZs8d7uFSt3eqNjM9NQ3g3uQCW5avD8mRNoXV99Yig50vjuaez6dQK2qC0kVWPRTujxY0dWgGfT09adjYg==",
+      "requires": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1"
+      }
+    },
+    "passport-github": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/passport-github/-/passport-github-1.1.0.tgz",
+      "integrity": "sha1-jOHj/NYa11eOsd9ZWDnkrqEjVdQ=",
+      "requires": {
+        "passport-oauth2": "1.x.x"
+      }
+    },
+    "passport-oauth2": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.5.0.tgz",
+      "integrity": "sha512-kqBt6vR/5VlCK8iCx1/KpY42kQ+NEHZwsSyt4Y6STiNjU+wWICG1i8ucc1FapXDGO15C5O5VZz7+7vRzrDPXXQ==",
+      "requires": {
+        "base64url": "3.x.x",
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      }
+    },
+    "passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha1-tVOaqPwiWj0a0XlHbd8ja0QPUuQ="
+    },
     "path-browserify": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
@@ -15117,6 +15161,11 @@
       "requires": {
         "pify": "^3.0.0"
       }
+    },
+    "pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
     },
     "pbkdf2": {
       "version": "3.1.1",
@@ -20376,6 +20425,11 @@
       "version": "3.9.7",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
       "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+    },
+    "uid2": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+      "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
     },
     "unfetch": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,8 @@
     "@types/morgan": "^1.9.1",
     "@types/node": "^14.0.27",
     "@types/node-fetch": "^2.5.7",
+    "@types/passport": "^1.0.4",
+    "@types/passport-github": "^1.1.5",
     "@types/react-router-dom": "^5.1.5",
     "@typescript-eslint/eslint-plugin": "^3.9.1",
     "@typescript-eslint/parser": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "express-validator": "^6.6.1",
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",
+    "passport": "^0.4.1",
+    "passport-github": "^1.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.2.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -71,6 +71,8 @@ model User {
   name             String    @default("")
   phone            String    @default("")
   email            String    @unique
+  profileImg       String?
+  token            String?
   createdAt        DateTime  @default(now())
   defaultAddressId Int?
   defaultAddress   Address?  @relation("AddressToUser_defaultAddressId", fields: [defaultAddressId], references: [id])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
+import {
+  BrowserRouter as Router,
+  Redirect,
+  Route,
+  Switch,
+} from 'react-router-dom'
 import './app.style.scss'
 import Bmart from './pages/Bmart'
 import Jjims from './pages/Jjims'
@@ -20,6 +25,9 @@ const App: React.FC = () => {
           </Route>
           <Route path="/jjims">
             <Jjims />
+          </Route>
+          <Route path="/verified">
+            <Redirect to="/"></Redirect>
           </Route>
         </Switch>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,5 @@
 import React, { createContext, useEffect, useState } from 'react'
-import {
-  BrowserRouter as Router,
-  Redirect,
-  Route,
-  Switch,
-} from 'react-router-dom'
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
 import './app.style.scss'
 import Bmart from './pages/Bmart'
 import Jjims from './pages/Jjims'
@@ -50,7 +45,7 @@ const AppRouter: React.FC = () => {
             <Jjims />
           </Route>
           <Route path="/verified">
-            <Redirect to="/"></Redirect>
+            <Bmart />
           </Route>
         </Switch>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,22 +10,22 @@ import Bmart from './pages/Bmart'
 import Jjims from './pages/Jjims'
 import { Dispatcher } from './types/react-helper'
 
-export const LoginContext = createContext<{
-  isLogged: boolean
-  setIsLogged: Dispatcher<boolean>
+export const SignedContext = createContext<{
+  isSigned: boolean
+  setSigned: Dispatcher<boolean>
 }>(undefined)
 
 const App: React.FC = () => {
-  const [isLogged, setIsLogged] = useState<boolean>(false)
+  const [isSigned, setSigned] = useState<boolean>(false)
 
   useEffect(() => {
     if (localStorage.getItem('token')) {
-      setIsLogged(true)
+      setSigned(true)
     }
   }, [])
 
   return (
-    <LoginContext.Provider value={{ isLogged, setIsLogged }}>
+    <SignedContext.Provider value={{ isSigned, setSigned }}>
       <Router>
         <div className="app">
           <Switch>
@@ -47,7 +47,7 @@ const App: React.FC = () => {
           </Switch>
         </div>
       </Router>
-    </LoginContext.Provider>
+    </SignedContext.Provider>
   )
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,45 +9,60 @@ import './app.style.scss'
 import Bmart from './pages/Bmart'
 import Jjims from './pages/Jjims'
 import { Dispatcher } from './types/react-helper'
+import { useSigned } from './utils/hooks'
 
 export const SignedContext = createContext<{
   isSigned: boolean
   setSigned: Dispatcher<boolean>
 }>(undefined)
 
-const App: React.FC = () => {
+const SignedContextProvider: React.FC = ({ children }) => {
   const [isSigned, setSigned] = useState<boolean>(false)
-
-  useEffect(() => {
-    if (localStorage.getItem('token')) {
-      setSigned(true)
-    }
-  }, [])
 
   return (
     <SignedContext.Provider value={{ isSigned, setSigned }}>
-      <Router>
-        <div className="app">
-          <Switch>
-            <Route path="/" exact>
-              <Bmart />
-            </Route>
-            <Route path="/sale" exact>
-              <Bmart />
-            </Route>
-            <Route path="/me" exact>
-              <Bmart />
-            </Route>
-            <Route path="/jjims">
-              <Jjims />
-            </Route>
-            <Route path="/verified">
-              <Redirect to="/"></Redirect>
-            </Route>
-          </Switch>
-        </div>
-      </Router>
+      {children}
     </SignedContext.Provider>
+  )
+}
+
+const AppRouter: React.FC = () => {
+  const { initSigned } = useSigned()
+
+  useEffect(() => {
+    initSigned()
+  }, [])
+
+  return (
+    <Router>
+      <div className="app">
+        <Switch>
+          <Route path="/" exact>
+            <Bmart />
+          </Route>
+          <Route path="/sale" exact>
+            <Bmart />
+          </Route>
+          <Route path="/me" exact>
+            <Bmart />
+          </Route>
+          <Route path="/jjims">
+            <Jjims />
+          </Route>
+          <Route path="/verified">
+            <Redirect to="/"></Redirect>
+          </Route>
+        </Switch>
+      </div>
+    </Router>
+  )
+}
+
+const App: React.FC = () => {
+  return (
+    <SignedContextProvider>
+      <AppRouter></AppRouter>
+    </SignedContextProvider>
   )
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createContext, useEffect, useState } from 'react'
 import {
   BrowserRouter as Router,
   Redirect,
@@ -8,30 +8,46 @@ import {
 import './app.style.scss'
 import Bmart from './pages/Bmart'
 import Jjims from './pages/Jjims'
+import { Dispatcher } from './types/react-helper'
+
+export const LoginContext = createContext<{
+  isLogged: boolean
+  setIsLogged: Dispatcher<boolean>
+}>(undefined)
 
 const App: React.FC = () => {
+  const [isLogged, setIsLogged] = useState<boolean>(false)
+
+  useEffect(() => {
+    if (localStorage.getItem('token')) {
+      setIsLogged(true)
+    }
+  }, [])
+
   return (
-    <Router>
-      <div className="app">
-        <Switch>
-          <Route path="/" exact>
-            <Bmart />
-          </Route>
-          <Route path="/sale" exact>
-            <Bmart />
-          </Route>
-          <Route path="/me" exact>
-            <Bmart />
-          </Route>
-          <Route path="/jjims">
-            <Jjims />
-          </Route>
-          <Route path="/verified">
-            <Redirect to="/"></Redirect>
-          </Route>
-        </Switch>
-      </div>
-    </Router>
+    <LoginContext.Provider value={{ isLogged, setIsLogged }}>
+      <Router>
+        <div className="app">
+          <Switch>
+            <Route path="/" exact>
+              <Bmart />
+            </Route>
+            <Route path="/sale" exact>
+              <Bmart />
+            </Route>
+            <Route path="/me" exact>
+              <Bmart />
+            </Route>
+            <Route path="/jjims">
+              <Jjims />
+            </Route>
+            <Route path="/verified">
+              <Redirect to="/"></Redirect>
+            </Route>
+          </Switch>
+        </div>
+      </Router>
+    </LoginContext.Provider>
   )
 }
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -11,15 +11,6 @@ import { PatchProductQuantityInCartApiRequestBody } from './../types/api'
 
 const baseURL = isDev ? `http://${window.location.hostname}:13100/api` : `/api`
 
-export function saveToken(token: string): void {
-  localStorage.setItem('token', token)
-}
-
-// TODO REMOVE THIS AFTER LOGIN IMPLEMENTATION
-saveToken(
-  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcklkIjoxNSwiaWF0IjoxNTE2MjM5MDIyfQ.OYhK3YG3W7iX5JxsQuwBn1ARPKVOgzh4GDs0FVqxols'
-)
-
 function loadToken(): string {
   return localStorage.getItem('token')
 }

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,4 +1,4 @@
-import { Jjim, Product } from '@prisma/client'
+import { Jjim, Product, User } from '@prisma/client'
 import type {
   DeleteFromCartBody,
   ProductsInCart,
@@ -115,4 +115,8 @@ export async function PatchProductQuantityInCart(
   body: PatchProductQuantityInCartApiRequestBody
 ): Promise<void> {
   await request('/product-quantity-in-cart', 'PATCH', body)
+}
+
+export async function getUser(): Promise<User> {
+  return await request('/me', 'GET')
 }

--- a/src/pages/Bmart/Me/index.tsx
+++ b/src/pages/Bmart/Me/index.tsx
@@ -4,7 +4,11 @@ import './style.scss'
 export type MeProps = unknown
 
 const Me: React.FC<MeProps> = (props) => {
-  return <div className="me">me</div>
+  return (
+    <div className="me">
+      <a href="/auth/login">로그인</a>
+    </div>
+  )
 }
 
 export default Me

--- a/src/pages/Bmart/Me/index.tsx
+++ b/src/pages/Bmart/Me/index.tsx
@@ -1,12 +1,37 @@
-import React from 'react'
+import { User } from '@prisma/client'
+import React, { useEffect, useState } from 'react'
+import { getUser } from 'src/apis'
+import { useSigned } from 'src/utils/hooks'
 import './style.scss'
 
 export type MeProps = unknown
 
 const Me: React.FC<MeProps> = (props) => {
+  const { isSigned, signOut } = useSigned()
+  const [user, setUser] = useState<User>(null)
+
+  async function loadUser() {
+    setUser(await getUser())
+  }
+
+  useEffect(() => {
+    if (isSigned) {
+      loadUser()
+
+      return
+    }
+
+    setUser(null)
+  }, [isSigned])
+
   return (
     <div className="me">
       <a href="/auth/login">로그인</a>
+      <a onClick={() => signOut()}>로그아웃</a>
+      <div>
+        {isSigned ? '로그인되어있음' : '로그인 안되어있음'}
+        {user && <img src={user.profileImg}></img>}
+      </div>
     </div>
   )
 }

--- a/src/pages/Bmart/index.tsx
+++ b/src/pages/Bmart/index.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 import { $$sel, $sel, sanitizeNan } from 'src/utils'
+import { useSigned } from 'src/utils/hooks'
 import Header from './Header'
 import Home from './Home'
 import Me from './Me'
@@ -75,6 +76,7 @@ const Bmart: React.FC<BmartProps> = () => {
 
   const location = useLocation()
   const history = useHistory()
+  const { signIn } = useSigned()
 
   useEffect(() => {
     const path = location.pathname.replace('/', '')
@@ -82,7 +84,7 @@ const Bmart: React.FC<BmartProps> = () => {
     if (path === 'verified') {
       const token = new URLSearchParams(location.search).get('token')
 
-      localStorage.setItem('token', token)
+      signIn(token)
 
       history.replace('/')
 

--- a/src/pages/Bmart/index.tsx
+++ b/src/pages/Bmart/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react'
-import { useLocation } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { $$sel, $sel, sanitizeNan } from 'src/utils'
 import Header from './Header'
 import Home from './Home'
@@ -74,10 +74,21 @@ const Bmart: React.FC<BmartProps> = () => {
   const slidePagesWrapper = useRef<HTMLDivElement>()
 
   const location = useLocation()
+  const history = useHistory()
 
   useEffect(() => {
-    console.log('location change')
     const path = location.pathname.replace('/', '')
+
+    if (path === 'verified') {
+      const token = new URLSearchParams(location.search).get('token')
+
+      localStorage.setItem('token', token)
+
+      history.replace('/')
+
+      return
+    }
+
     const index = path === '' ? 0 : path === 'sale' ? 1 : path === 'me' ? 2 : 0
 
     navigateSlidePageTo(index, '0', undefined, false)

--- a/src/server/api/add-to-cart.ts
+++ b/src/server/api/add-to-cart.ts
@@ -10,7 +10,10 @@ const addToCartRouter = express.Router()
 
 addToCartRouter.post(
   '/add-to-cart',
-  [body('productId').isInt(), body('quantity').isInt({ min: CONSTRAINT.MIN_QUANTITY })],
+  [
+    body('productId').isInt(),
+    body('quantity').isInt({ min: CONSTRAINT.MIN_QUANTITY }),
+  ],
   requestValidator(),
   async (req: Request<{}, {}, AddToCartRequestBody>, res: Response) => {
     const userId = req.auth?.userId as number

--- a/src/server/api/get-user-info.ts
+++ b/src/server/api/get-user-info.ts
@@ -5,25 +5,30 @@ import { prisma } from '../utils/prisma'
 
 const getUserInfoRouter = express.Router()
 
-getUserInfoRouter.get('/me', async (req: Request, res: Response<GetUserInfoApiResponse>) => {
-  const userId = req.auth?.userId
+getUserInfoRouter.get(
+  '/me',
+  async (req: Request, res: Response<GetUserInfoApiResponse>) => {
+    const userId = req.auth?.userId
 
-  try {
-    const user = await prisma.user.findOne({
-      where: {
-        id: userId,
-      },
-      include: {
-        addresses: true,
-      },
-    })
+    try {
+      const user = await prisma.user.findOne({
+        where: {
+          id: userId,
+        },
+        include: {
+          addresses: true,
+        },
+      })
 
-    res.json(user)
-  } catch (e) {
-    console.error(e)
+      res.json(user)
+    } catch (e) {
+      console.error(e)
 
-    res.status(STATUS_CODE.INTERNAL_ERROR).send({ message: ERROR_MSG.INTERNAL_ERROR })
+      res
+        .status(STATUS_CODE.INTERNAL_ERROR)
+        .send({ message: ERROR_MSG.INTERNAL_ERROR })
+    }
   }
-})
+)
 
 export { getUserInfoRouter }

--- a/src/server/api/get-user-info.ts
+++ b/src/server/api/get-user-info.ts
@@ -20,6 +20,7 @@ getUserInfoRouter.get(
         },
       })
 
+      delete user?.token
       res.json(user)
     } catch (e) {
       console.error(e)

--- a/src/server/api/get-user-info.ts
+++ b/src/server/api/get-user-info.ts
@@ -8,12 +8,12 @@ const getUserInfoRouter = express.Router()
 getUserInfoRouter.get(
   '/me',
   async (req: Request, res: Response<GetUserInfoApiResponse>) => {
-    const userId = req.auth?.userId
+    const userId = req.auth?.userId || ''
 
     try {
       const user = await prisma.user.findOne({
         where: {
-          id: userId,
+          email: userId,
         },
         include: {
           addresses: true,

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -1,0 +1,3 @@
+import express from 'express'
+
+export const authRouter = express.Router()

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -1,3 +1,69 @@
-import express from 'express'
+import dotenv from 'dotenv'
+import express, { Request, Response } from 'express'
+import passport from 'passport'
+import { Strategy } from 'passport-github'
+import { prisma } from '~/utils/prisma'
+import { STATUS_CODE } from './../../constants/index'
+
+dotenv.config()
+const clientID = process.env.GITHUB_CLIENT_ID || ''
+const clientSecret = process.env.GITHUB_CLIENT_SECRET || ''
+const callbackURL = process.env.GITHUB_CALLBACK_URL || ''
 
 export const authRouter = express.Router()
+
+authRouter.use(passport.initialize())
+passport.use(
+  new Strategy(
+    {
+      clientID,
+      clientSecret,
+      callbackURL,
+    },
+    async (token, _, profile, done) => {
+      const name = profile.displayName
+      const email = profile.emails?.map((x) => x.value).find(() => true) ?? ''
+      const profileImg =
+        profile.photos?.map((x) => x.value).find(() => true) ?? ''
+
+      console.log('hi')
+      await prisma.user.upsert({
+        create: {
+          email,
+          name,
+          profileImg,
+          token,
+        },
+        update: {
+          profileImg,
+          token,
+        },
+        where: {
+          email: email,
+        },
+      })
+      console.log('done!', name, email, profileImg)
+
+      await prisma.$disconnect()
+      done(null, profile)
+    }
+  )
+)
+
+authRouter.get('/login', passport.authenticate('github', { session: false }))
+authRouter.get('/logout', (req, res) => {
+  req.logout()
+  res.sendStatus(STATUS_CODE.OK).end()
+})
+authRouter.get(
+  '/callback',
+  passport.authenticate('github', { session: false }),
+  (req: Request, res: Response) => {
+    const userId = req.auth?.userId
+
+    console.log(req.user)
+
+    console.log('done!!')
+    res.send({ login: 'OK', userId: req.user })
+  }
+)

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -6,6 +6,7 @@ import bearerToken from 'express-bearer-token'
 import morgan from 'morgan'
 import { isDev } from './../utils'
 import { apiRouter } from './api'
+import { authRouter } from './auth'
 import { tokenVerifier } from './middlewares'
 
 const app = express()
@@ -27,6 +28,7 @@ if (!isDev) {
   app.use(express.static(appRoot.resolve('/build')))
 }
 
+app.use('/auth', authRouter)
 app.use('/api', apiRouter)
 
 if (!isDev) {

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -9,7 +9,7 @@ export function useSigned() {
     setSigned(true)
   }
 
-  function signOut(token) {
+  function signOut() {
     localStorage.removeItem('token')
     setSigned(false)
   }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -1,0 +1,24 @@
+import { useContext } from 'react'
+import { SignedContext } from './../App'
+
+export function useSigned() {
+  const { isSigned, setSigned } = useContext(SignedContext)
+
+  function signIn(token) {
+    localStorage.setItem('token', token)
+    setSigned(true)
+  }
+
+  function signOut(token) {
+    localStorage.removeItem('token')
+    setSigned(false)
+  }
+
+  function initSigned() {
+    if (localStorage.getItem('token')) {
+      setSigned(true)
+    }
+  }
+
+  return { signIn, signOut, initSigned, isSigned }
+}


### PR DESCRIPTION
### .env 변경
- 슬랙 참고
- .env.dev .env.prod 요런 식으로 2개의 .env를 번갈아가면서 사용하면 좋을듯 
- 로컬에서 개발 할 때랑 서버에서 개발 할 때랑 다른 ClientID와 Secret을 요구하기 때문에.. (OAuth Provider와 연결되어있는 callback 주소가 각각 다름)

### 로그인 정보
- useSigned 훅을 통해서 토큰 저장/불러오기 가능

### 인증 과정
- `/auth/login`, `/auth/callback` 두 개의 정보가 있음
- `/auth/login`으로 접속하면 깃허브창에서 로그인을 연결할 수 있고, 인증이 완료되면 깃허브에서 `/auth/callback`으로 토큰 정보를 돌려줌
- 깃허브에서 인증이 완료될 때 마다 처리하는 부분은 백앤드의 authRouter의 GithubStrategy 부분 참고
    - 토큰 정보를 받으면 DB에 깃허브 토큰을 저장하고 `done(null, obj)`을 실행하면 `req.user`에 obj가 들어감
- 인증정보가 들어오면 `클라이언트 주소/verified?token={}`식으로 서버에서 클라이언트로 토큰 정보를 보냄
- <Bmart>에서 해당 토큰부분을 파싱해서 useSigned 훅으로 토큰을 로컬 스토리지에 저장하고 로그인 상태(isSigned)를 true로 바꿈
