### PR TITLE
Get categorys hotifx

### DIFF
--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -2,8 +2,8 @@ import { Jjim, Product, User } from '@prisma/client'
 import type {
   AddToCartRequestBody,
   DeleteFromCartBody,
-  GetProductsByCategoryApiRequestQuery,
   GetProductApiRequestQuery,
+  GetProductsByCategoryApiRequestQuery,
   GetProductsByTopicResponse,
   GetProductsInCartResponse,
   ProductWithJjimmed,
@@ -120,6 +120,22 @@ export async function getProductsByCategory(
   return await request(
     `/products-by-category${createQuery({
       category,
+      page: page.toString(),
+      sortBy,
+      direction,
+    })}`,
+    'GET'
+  )
+}
+
+export async function getProductsBySubCategory(
+  query: GetProductsByCategoryApiRequestQuery
+): Promise<Product[] | ProductWithJjimmed[]> {
+  const { subCategory, page, sortBy, direction } = query
+
+  return await request(
+    `/products-by-category${createQuery({
+      subCategory,
       page: page.toString(),
       sortBy,
       direction,

--- a/src/components/SlotMachine/style.scss
+++ b/src/components/SlotMachine/style.scss
@@ -9,6 +9,8 @@ body {
 .slot-machine {
   font-size: 22px;
   font-weight: 600px;
+  display: flex;
+  justify-content: center;
 
   .pullable {
     overflow: scroll;
@@ -17,8 +19,8 @@ body {
   .slot {
     transition-property: transform;
     display: inline-block;
+    max-width: 800px;
     width: 100%;
-    margin-top: 0;
 
     .slot-body {
       height: 40px;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -10,6 +10,7 @@ export const ERROR_MSG = {
   EMPTY_ADDRESS: '빈 주소를 입력할 수 없습니다.',
   NOT_YOUR_ADDRESS: '수정하거나 삭제할 수 없는 주소입니다.',
   INVALID_TOPIC: '토픽이 유효하지 않거나 존재하지 않습니다.',
+  NO_CATEGORY: '유효한 카테고리 정보가 없습니다.',
 }
 
 export const STATUS_CODE = {

--- a/src/pages/CategoryDetails/index.tsx
+++ b/src/pages/CategoryDetails/index.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react'
 import { useHistory, useParams } from 'react-router-dom'
-import { getProductsByCategory } from 'src/apis'
+import { getProductsBySubCategory } from 'src/apis'
 import Drawer from 'src/components/Drawer'
 import ArrowUpDownIcon from 'src/components/icons/ArrowUpDownIcon'
 import ChevronDownIcon from 'src/components/icons/ChevronDownIcon'
@@ -52,8 +52,8 @@ const Component: React.FC<CategoryDetailsProps> = ({ category }) => {
 
   async function getProducts() {
     setLoading(true)
-    const newProducts = (await getProductsByCategory({
-      category: subCategory,
+    const newProducts = (await getProductsBySubCategory({
+      subCategory,
       page,
       ...sortByResolver(sortBy),
     })) as ProductWithJjimmed[]

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -25,7 +25,8 @@ export type DeleteFromCartBody = {
 export type GetJjimsApiResponse = Jjim[] | ErrorResponse
 
 export type GetProductsByCategoryApiRequestQuery = {
-  category: string
+  category?: string
+  subCategory?: string
   page?: number
   amount?: number
   sortBy?: string


### PR DESCRIPTION
- get-products-by-category api자체는 이제 category, subCategory 2개의 인자를 가집니다.
- query로 category도 없고 subCategory도 없는 경우에는 `ERROR_MSG.NO_CATEGORY`를 반환합니다.
- Sale페이지에서는 getProductsByCategory, CategoryDetails에서는 getProductsBySubCategory를 호출합니다.
- 슬롯 머신의 max-width를 추가했습니다
