### PR TITLE
Refactor and fix

### DIFF
--- a/src/app.style.scss
+++ b/src/app.style.scss
@@ -1,4 +1,5 @@
 #root,
 .app {
   height: 100%;
+  overflow: auto;
 }

--- a/src/components/Carousel/Dots/index.tsx
+++ b/src/components/Carousel/Dots/index.tsx
@@ -5,7 +5,7 @@ import './style.scss'
 
 export type DotsProps = unknown
 
-const Dots: React.FC<DotsProps> = (props) => {
+const Dots: React.FC<DotsProps> = () => {
   const { totalNumber, currentIndex } = useContext(CarouselContext)
 
   return (

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -52,6 +52,16 @@ const Drawer: React.FC<DrawerProps> = ({
     containerRef.current.style.maxHeight = `calc(${maxHeight} - var(--holder-height) - 15px)`
   }, [])
 
+  // Init background oapcity to 0 without transition
+  useEffect(() => {
+    backgroundRef.current.style.transition = 'none'
+    backgroundRef.current.style.opacity = '0.3'
+
+    setTimeout(() => {
+      backgroundRef.current.style.transition = ''
+    }, 0)
+  }, [])
+
   useEffect(() => {
     moveRef(bodyRef, {
       position: isOpened ? 0 : getRefHeight(bodyRef),
@@ -191,7 +201,7 @@ function moveRef(
 
   const { position, smooth = false } = options
 
-  ref.current.style.transform = `translateY(${position}px)`
+  ref.current.style.transform = `translateX(-50%) translateY(${position}px)`
   ref.current.style.transition = smooth ? `transform 500ms ease` : ``
 }
 

--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -55,7 +55,7 @@ const Drawer: React.FC<DrawerProps> = ({
   // Init background oapcity to 0 without transition
   useEffect(() => {
     backgroundRef.current.style.transition = 'none'
-    backgroundRef.current.style.opacity = '0.3'
+    backgroundRef.current.style.opacity = '0'
 
     setTimeout(() => {
       backgroundRef.current.style.transition = ''

--- a/src/components/Drawer/style.scss
+++ b/src/components/Drawer/style.scss
@@ -16,10 +16,12 @@
 
   .body {
     position: fixed;
-    left: 0;
+    left: 50%;
+    transform: translateX(-50%);
     z-index: 2;
     bottom: 0;
-    width: 100vw;
+    width: 100%;
+    max-width: 600px;
     background-color: var(--layered-foundation);
     border-radius: 20px 20px 0 0;
 

--- a/src/components/MinusPlus/index.tsx
+++ b/src/components/MinusPlus/index.tsx
@@ -17,11 +17,17 @@ const MinusPlus: React.FC<MinusPlusProps> = ({ quantity = 1, onChange }) => {
 
   return (
     <div className="minus-plus">
-      <div onClick={() => changeQuantity(quantity - 1)}>
+      <div
+        className="icon-wrapper"
+        onClick={() => changeQuantity(quantity - 1)}
+      >
         <MinusIcon></MinusIcon>
       </div>
-      <div>{quantity}</div>
-      <div onClick={() => changeQuantity(quantity + 1)}>
+      <div className="quantity">{quantity}</div>
+      <div
+        className="icon-wrapper"
+        onClick={() => changeQuantity(quantity + 1)}
+      >
         <PlusIcon></PlusIcon>
       </div>
     </div>

--- a/src/components/MinusPlus/style.scss
+++ b/src/components/MinusPlus/style.scss
@@ -1,21 +1,27 @@
 @use '~src/styles/design-system' as *;
 
 .minus-plus {
-  $height: 44.79px;
+  $height: 45px;
 
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 0 #{$height / 2};
-  width: 142.28px;
+  width: 100%;
   height: $height;
   left: 154.8px;
   top: 30.02px;
   background: var(--layered-element);
   border-radius: $circle;
 
-  div {
+  .icon-wrapper {
     display: flex;
     align-items: center;
+    justify-content: center;
+    width: 45px;
+    height: 45px;
+  }
+
+  .quantity {
+    flex: 1;
   }
 }

--- a/src/components/SlotMachine/style.scss
+++ b/src/components/SlotMachine/style.scss
@@ -14,26 +14,36 @@ body {
 
   .pullable {
     overflow: scroll;
+    width: 100%;
   }
 
   .slot {
     transition-property: transform;
     display: inline-block;
-    max-width: 800px;
     width: 100%;
 
     .slot-body {
       height: 40px;
       display: flex;
       align-items: center;
-      justify-content: space-around;
+      justify-content: center;
     }
+  }
+
+  .menu,
+  .pull-label {
+    font-size: 20px;
   }
 
   .menu {
     display: inline-block;
-    margin-left: 2em;
-    width: 8 em;
+    width: 6em;
+    text-align: right;
+  }
+
+  .pull-label {
+    margin-left: 10px;
+    margin-right: 3em;
   }
 
   .content {

--- a/src/pages/Bmart/Sale/index.tsx
+++ b/src/pages/Bmart/Sale/index.tsx
@@ -88,20 +88,24 @@ const Sale: React.FC<SaleProps> = () => {
 
   useEffect(() => {
     async function init() {
-      for (const category of DEFAULTS.CATEGORIES) {
-        const products = (await request(
-          `/products-by-category${createQuery({
-            category: category,
-            sortBy: 'discount',
-            direction: 'desc',
-            amount: '1',
-            page: '1',
-          })}`,
-          'GET'
-        )) as ProductWithJjimmed[]
+      const allProducts = (
+        await Promise.all(
+          DEFAULTS.CATEGORIES.map((category) =>
+            request(
+              `/products-by-category${createQuery({
+                category: category,
+                sortBy: 'discount',
+                direction: 'desc',
+                amount: '1',
+                page: '1',
+              })}`,
+              'GET'
+            )
+          )
+        )
+      ).flat()
 
-        setSaleProducts((prev) => [...prev, ...products])
-      }
+      setSaleProducts((prev) => [...prev, ...allProducts])
     }
 
     init()

--- a/src/pages/ProductDetails/index.tsx
+++ b/src/pages/ProductDetails/index.tsx
@@ -9,6 +9,7 @@ import ColorfulHeartIcon from 'src/components/icons/ColorfulHeartIcon'
 import DiscountLabel from 'src/components/icons/DiscountLabel'
 import ResizableCartIcon from 'src/components/icons/ResizableCartIcon'
 import MinusPlus from 'src/components/MinusPlus'
+import GoBack from 'src/components/shortcuts/GoBack'
 import { Dialog } from 'src/utils/dialog'
 import { useSigned } from 'src/utils/hooks'
 import './style.scss'
@@ -69,7 +70,8 @@ const ProductDetails: React.FC<ProductDetailsProps> = () => {
     <div className="product-details">
       {product && (
         <>
-          <img className="product-details-image" src={product.imgH}></img>
+          <GoBack />
+          <img className="product-details-image" src={product.imgH} />
           <div className="product-details-info">
             <div className="product-details-info-category">
               {product.category}

--- a/src/pages/ProductDetails/index.tsx
+++ b/src/pages/ProductDetails/index.tsx
@@ -68,73 +68,75 @@ const ProductDetails: React.FC<ProductDetailsProps> = () => {
 
   return (
     <div className="product-details">
-      {product && (
-        <>
-          <GoBack />
-          <img className="product-details-image" src={product.imgH} />
-          <div className="product-details-info">
-            <div className="product-details-info-category">
-              {product.category}
-              <ChevronRightIcon />
-              {product.subcategory}
-            </div>
-            <div className="product-details-info-description">
-              {product.description}
-            </div>
-            <div className="product-details-info-name">{product.name}</div>
-            <div className="product-details-info-price-info">
-              {Boolean(product.discount) && (
-                <DiscountLabel size="big" discount={product.discount} />
-              )}
-              <div className="product-details-info-price-info-price">
-                {product.defaultPrice !== product.price && (
-                  <span className="product-details-info-price-info-price-default">
-                    {product.defaultPrice.toLocaleString()}원
+      <div>
+        {product && (
+          <>
+            <GoBack />
+            <img className="product-details-image" src={product.imgH} />
+            <div className="product-details-info">
+              <div className="product-details-info-category">
+                {product.category}
+                <ChevronRightIcon />
+                {product.subcategory}
+              </div>
+              <div className="product-details-info-description">
+                {product.description}
+              </div>
+              <div className="product-details-info-name">{product.name}</div>
+              <div className="product-details-info-price-info">
+                {Boolean(product.discount) && (
+                  <DiscountLabel size="big" discount={product.discount} />
+                )}
+                <div className="product-details-info-price-info-price">
+                  {product.defaultPrice !== product.price && (
+                    <span className="product-details-info-price-info-price-default">
+                      {product.defaultPrice.toLocaleString()}원
+                    </span>
+                  )}
+                  <span className="product-details-info-price-info-price-current">
+                    {product.price.toLocaleString()}원
                   </span>
-                )}
-                <span className="product-details-info-price-info-price-current">
-                  {product.price.toLocaleString()}원
-                </span>
+                </div>
               </div>
-            </div>
-            <div className="product-details-info-options">
-              <div
-                className="product-details-info-options-jjim"
-                onClick={onToggleJjim}
-              >
-                {isJjimmed ? (
-                  <ColorfulBrokenHeartIcon width="75px" />
-                ) : (
-                  <ColorfulHeartIcon width="75px" />
-                )}
-              </div>
-              <div
-                className="product-details-info-options-cart"
-                onClick={onCartClick}
-              >
-                <ResizableCartIcon width="50px" />
-              </div>
-            </div>
-          </div>
-          <Drawer isOpened={isCartOpened} setOpened={setIsCartOpened}>
-            <div className="product-details-cart">
-              <img
-                className="product-details-cart-image"
-                src={product.imgV}
-              ></img>
-              <div className="product-details-cart-buttons">
-                <MinusPlus quantity={quantity} onChange={setQuantity} />
+              <div className="product-details-info-options">
                 <div
-                  className="product-details-cart-buttons-confirm"
-                  onClick={onConfirm}
+                  className="product-details-info-options-jjim"
+                  onClick={onToggleJjim}
                 >
-                  담기
+                  {isJjimmed ? (
+                    <ColorfulBrokenHeartIcon width="75px" />
+                  ) : (
+                    <ColorfulHeartIcon width="75px" />
+                  )}
+                </div>
+                <div
+                  className="product-details-info-options-cart"
+                  onClick={onCartClick}
+                >
+                  <ResizableCartIcon width="50px" />
                 </div>
               </div>
             </div>
-          </Drawer>
-        </>
-      )}
+            <Drawer isOpened={isCartOpened} setOpened={setIsCartOpened}>
+              <div className="product-details-cart">
+                <img
+                  className="product-details-cart-image"
+                  src={product.imgV}
+                ></img>
+                <div className="product-details-cart-buttons">
+                  <MinusPlus quantity={quantity} onChange={setQuantity} />
+                  <div
+                    className="product-details-cart-buttons-confirm"
+                    onClick={onConfirm}
+                  >
+                    담기
+                  </div>
+                </div>
+              </div>
+            </Drawer>
+          </>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/pages/ProductDetails/style.scss
+++ b/src/pages/ProductDetails/style.scss
@@ -1,13 +1,21 @@
 .product-details {
   width: 100%;
+  text-align: center;
 
   &-image {
-    width: 100%;
+    width: calc(100% - var(--ordinary-space) * 2);
+    max-width: 700px;
+    border-radius: 10px;
+    margin: auto;
+    margin-top: var(--ordinary-space);
     height: auto;
   }
 
   &-info {
     padding: 25px 15px 0;
+    text-align: left;
+    max-width: 500px;
+    margin: auto;
 
     &-category {
       font-size: 12px;

--- a/src/pages/ProductDetails/style.scss
+++ b/src/pages/ProductDetails/style.scss
@@ -1,6 +1,10 @@
 .product-details {
   width: 100%;
   text-align: center;
+  min-height: 80%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 
   &-image {
     width: calc(100% - var(--ordinary-space) * 2);

--- a/src/pages/ProductDetails/style.scss
+++ b/src/pages/ProductDetails/style.scss
@@ -1,18 +1,24 @@
+@use '~src/styles/design-system' as *;
+
 .product-details {
   width: 100%;
   text-align: center;
-  min-height: 80%;
+  // min-height: 90%;
   display: flex;
   flex-direction: column;
   justify-content: center;
 
   &-image {
     width: calc(100% - var(--ordinary-space) * 2);
-    max-width: 700px;
+    max-width: 600px;
     border-radius: 10px;
     margin: auto;
-    margin-top: var(--ordinary-space);
+    margin-top: 30px;
     height: auto;
+
+    @include larger-than(650px) {
+      border-radius: 20px;
+    }
   }
 
   &-info {
@@ -20,6 +26,14 @@
     text-align: left;
     max-width: 500px;
     margin: auto;
+
+    @include larger-than(650px) {
+      max-width: 600px;
+      padding: 30px 40px;
+      margin-top: 30px;
+      border-radius: 20px;
+      background-color: var(--element);
+    }
 
     &-category {
       font-size: 12px;
@@ -73,6 +87,12 @@
       display: flex;
       justify-content: space-around;
       align-items: center;
+      padding-top: 30px;
+      border-top: 1px solid rgba($color: #000, $alpha: 0.1);
+
+      @include dark-mode {
+        border-top: 1px solid rgba($color: #fff, $alpha: 0.1);
+      }
     }
   }
 

--- a/src/styles/base.scss
+++ b/src/styles/base.scss
@@ -1,5 +1,9 @@
 @use './fonts';
 
+::-webkit-scrollbar {
+  display: none;
+}
+
 :root {
   /* Colors */
   --bmart-shadow: 0 1px 4px rgba(0, 0, 0, 0.25);


### PR DESCRIPTION
**이 풀리퀘스트는 몇 가지 오류 사항 및 레이아웃 이슈를 해결합니다.**

- 번개세일의 상품을 서버에서 요청이 모두 끝나면 렌더링합니다. (이전에는 상품가 로드 될 때마다 렌더링)
- 슬롯 머신 레이아웃 수정
  - `max-width` 제거 및 당겨요 메시지를 조금 더 안정적이고 오밀조밀하게 업데이트
- 드로어(Drawer)의 검은 배경이 나타났다가 사라지는 현상(flickering) 수정
- 드로어(Drawer)의 최대 너비를 조절
- 마이너스 플러스 컴포넌트의 기본 width를 100%로 변경
  - ⚠️ **기존의 마이너스 플러스 컴포넌트를 사용하고 있던 페이지에서 레이아웃 이슈가 발생할 수 있습니다. 확인해주세요**
- 상품 상세 페이지에 뒤로 가기 버튼을 추가