### PR TITLE
Skeleton UI 추가 및 드로어 기능 추가

### DIFF
--- a/src/components/Drawer/index.tsx
+++ b/src/components/Drawer/index.tsx
@@ -190,7 +190,9 @@ function getFirstTouchY(event: React.TouchEvent) {
 function getRefHeight(ref: RefObject<HTMLDivElement>): number {
   if (!ref?.current) return 0
 
-  return ref.current.getBoundingClientRect().height
+  return ref.current.clientHeight
+
+  // return ref.current.getBoundingClientRect().height
 }
 
 function moveRef(
@@ -201,7 +203,12 @@ function moveRef(
 
   const { position, smooth = false } = options
 
-  ref.current.style.transform = `translateX(-50%) translateY(${position}px)`
+  if (position === -1) {
+    ref.current.style.transform = `translateX(-50%) translateY(110%)`
+  } else {
+    ref.current.style.transform = `translateX(-50%) translateY(${position}px)`
+  }
+
   ref.current.style.transition = smooth ? `transform 500ms ease` : ``
 }
 

--- a/src/components/LazyLoader/index.tsx
+++ b/src/components/LazyLoader/index.tsx
@@ -14,7 +14,6 @@ export const LazyLoaderContext = createContext<{
 
 const LazyLoader: React.FC<LazyLoaderProps> = ({
   isRemovable = false,
-  hasCallback = false,
   children,
 }) => {
   const sentinelRef = useRef<HTMLDivElement>()
@@ -41,7 +40,7 @@ const LazyLoader: React.FC<LazyLoaderProps> = ({
     <div className="lazy-loader">
       <LazyLoaderContext.Provider value={{ isLoaded, setLoaded }}>
         <div className="sentinel" ref={sentinelRef}></div>
-        {children}
+        {(!isRemovable || (isRemovable && isLoaded)) && children}
       </LazyLoaderContext.Provider>
     </div>
   )

--- a/src/components/ProductContainer/index.tsx
+++ b/src/components/ProductContainer/index.tsx
@@ -9,6 +9,7 @@ import './style.scss'
 export type ProductContainerProps = {
   isSkeletonOn: boolean
   isEmpty?: boolean
+  onClick?: () => void
   products: (Product | ProductWithJjimmed)[]
   onLoadMore?: () => void
 }
@@ -18,6 +19,7 @@ export type ProductContainerProps = {
 const ProductContainer: React.FC<ProductContainerProps> = ({
   isSkeletonOn,
   products,
+  onClick,
   isEmpty,
   onLoadMore,
 }) => {
@@ -104,7 +106,7 @@ const ProductContainer: React.FC<ProductContainerProps> = ({
             //   }ms`,
             // }}
           >
-            <ProductItem {...result} />
+            <ProductItem {...result} onClick={onClick} />
           </div>
         ))}
 

--- a/src/components/ProductItem/index.tsx
+++ b/src/components/ProductItem/index.tsx
@@ -20,6 +20,7 @@ export type ProductItemProps = {
   imgV?: string
   isJjimmed?: boolean
   isSkeleton?: boolean
+  onClick?: () => void
   size?: 'small' | 'big'
 }
 
@@ -43,6 +44,7 @@ const ProductItem: React.FC<ProductItemProps> = ({
   price = 0,
   discount = 0,
   imgV = '',
+  onClick,
   isJjimmed = false,
   isSkeleton = false,
   size = 'small',
@@ -82,6 +84,7 @@ const ProductItem: React.FC<ProductItemProps> = ({
       isLongPress = false
     } else {
       initSetting()
+      onClick && onClick()
       history.push(`/products/${id}`)
     }
   }

--- a/src/components/Search/index.tsx
+++ b/src/components/Search/index.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { search } from 'src/apis'
 import ProductContainer from 'src/components/ProductContainer'
 import { useSigned } from 'src/utils/hooks'
+import { DrawerContext } from '../Drawer'
 import SearchInputContainer from './SearchInputContainer'
 import SearchTerms from './SearchTerms'
 import './style.scss'
@@ -45,6 +46,7 @@ const Search: React.FC<SearchProps> = ({ topMargin = '20px' }) => {
   const [recentTerms, setRecentTerms] = useState(getRecentTerms())
   const [isKeywordsOn, setIsKeywordsOn] = useState(true)
   const { isSigned } = useSigned()
+  const { closeDrawer } = useContext(DrawerContext)
 
   useEffect(() => {
     if (!isSigned) {
@@ -136,6 +138,7 @@ const Search: React.FC<SearchProps> = ({ topMargin = '20px' }) => {
           isSkeletonOn={isSkeletonOn}
           products={foundProducts}
           onLoadMore={onLoadMore}
+          onClick={closeDrawer}
         />
       )}
     </div>

--- a/src/components/SlotMachine/index.tsx
+++ b/src/components/SlotMachine/index.tsx
@@ -22,8 +22,8 @@ type ActionType =
   | typeof RESETING
   | typeof QUICK_RESETING
 
-const MIN_PULL_LENGTH = 100
-const MAX_PULL_LENGTH = 600
+const MIN_PULL_LENGTH = 150
+const MAX_PULL_LENGTH = 500
 const RELEASING_DURATION = 1000
 const RESETING_DURATION = 200
 const WAITING_DURATION = 500
@@ -166,7 +166,7 @@ const SlotMachine: React.FC<SlotMachineProps> = ({
       y = MAX_PULL_LENGTH * formula(y / MAX_PULL_LENGTH)
     }
 
-    moveSlotDown(y / 4)
+    moveSlotDown(y / 3)
   }
 
   function animateSlotMenu(y, height) {

--- a/src/pages/Addresses/AddressItem/index.tsx
+++ b/src/pages/Addresses/AddressItem/index.tsx
@@ -4,18 +4,44 @@ import CheckIcon from 'src/components/icons/CheckIcon'
 import './style.scss'
 
 export type AddressItemProps = {
-  address1: string
-  address2: string
+  address1?: string
+  address2?: string
   isDefault?: boolean
   onEdit?: () => void
   onDelete?: () => void
   onSelect?: () => void
+  isSkeleton?: boolean
+}
+
+const SkeletonUI: React.FC = () => {
+  return (
+    <div className="address-item">
+      <div className="check">
+        <CheckIcon width="20px"></CheckIcon>
+      </div>
+      <div className="row">
+        <span className="edit">
+          <span className="mock">수정</span>
+        </span>
+        <span className="delete">
+          <span className="mock red">삭제</span>
+        </span>
+      </div>
+      <div className="address">
+        <span className="mock">dfdfddddd</span>
+      </div>
+      <div className="address">
+        <span className="mock">dfdfdaaa</span>
+      </div>
+    </div>
+  )
 }
 
 const AddressItem: React.FC<AddressItemProps> = ({
   address1,
   address2,
   isDefault = false,
+  isSkeleton = false,
   onEdit,
   onDelete,
   onSelect,
@@ -36,7 +62,9 @@ const AddressItem: React.FC<AddressItemProps> = ({
     onSelect && onSelect()
   }
 
-  return (
+  return isSkeleton ? (
+    <SkeletonUI></SkeletonUI>
+  ) : (
     <div
       className={$(['address-item', { default: isDefault }])}
       onClick={onItemClick}

--- a/src/pages/Addresses/AddressItem/style.scss
+++ b/src/pages/Addresses/AddressItem/style.scss
@@ -13,6 +13,20 @@
   flex-direction: column;
   box-shadow: 0 0 0 2px none;
 
+  .mock {
+    border-radius: 7px;
+    height: 0.8em;
+    line-height: 140%;
+    margin-right: 0.7em;
+    background-color: #bbb;
+    color: #bbb;
+
+    &.red {
+      background-color: red;
+      color: red;
+    }
+  }
+
   .check {
     position: absolute;
     top: $padding;

--- a/src/pages/Addresses/index.tsx
+++ b/src/pages/Addresses/index.tsx
@@ -55,10 +55,12 @@ const Addresses: React.FC<AddressesProps> = () => {
   const [defaultAddress, setDefaultAddress] = useState<number>(0)
   const [isEditOpen, setEditOpen] = useState(false)
   const [isAddOpen, setAddOpen] = useState(false)
+  const [isLoading, setLoading] = useState(true)
 
   async function getAddresses() {
     const user = await getUser()
 
+    setLoading(false)
     setDefaultAddress(user.defaultAddressId)
     setAddresses(user.addresses)
   }
@@ -116,13 +118,20 @@ const Addresses: React.FC<AddressesProps> = () => {
         Icon={ParcelIcon.bind({}, { widith: '46px' })}
         title="배송지 관리"
       ></PageHeader>
-      <AddressContainer
-        addresses={addresses}
-        defaultAddress={defaultAddress}
-        onDefaultSelect={onDefaultSelect}
-        onDelete={onDelete}
-        onEdit={onEdit}
-      ></AddressContainer>
+      {isLoading ? (
+        <>
+          <AddressItem isSkeleton={true}></AddressItem>
+          <AddressItem isSkeleton={true}></AddressItem>
+        </>
+      ) : (
+        <AddressContainer
+          addresses={addresses}
+          defaultAddress={defaultAddress}
+          onDefaultSelect={onDefaultSelect}
+          onDelete={onDelete}
+          onEdit={onEdit}
+        ></AddressContainer>
+      )}
       <div className="add" onClick={onAddressPlus}>
         <PlusIcon></PlusIcon>
       </div>

--- a/src/pages/Bmart/Home/TopicContainer/index.tsx
+++ b/src/pages/Bmart/Home/TopicContainer/index.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { getProductsByTopic } from 'src/apis'
 import ProductItem from 'src/components/ProductItem'
 import { ProductWithJjimmed } from 'src/types/api'
+import { useLazy } from 'src/utils/hooks'
 import './style.scss'
 
 export type TopicContainerProps = {
@@ -33,9 +34,7 @@ const TopicContainer: React.FC<TopicContainerProps> = ({
     })
   }
 
-  useEffect(() => {
-    initLoadProducts()
-  }, [])
+  useLazy(initLoadProducts)
 
   // useLazy(initLoadProducts)
   const [scrollEnd, setScrollEnd] = useState<'left' | 'right' | 'middle'>(

--- a/src/pages/Bmart/Home/index.tsx
+++ b/src/pages/Bmart/Home/index.tsx
@@ -5,6 +5,7 @@ import CategoryItem, {
   CategoryItemType,
   categoryNames,
 } from 'src/components/CategoryItem'
+import LazyLoader from 'src/components/LazyLoader'
 import SlotMachine from 'src/components/SlotMachine'
 import { $sel } from 'src/utils'
 import { restoreScroll } from 'src/utils/scroll-manager'
@@ -27,17 +28,19 @@ const Home: React.FC<HomeProps> = () => {
             )}
           </div>
         </div>
+        <LazyLoader>
+          <TopicContainer title="🤔 지금 뭐 먹지?" type="now" />
+        </LazyLoader>
 
-        <TopicContainer title="🤔 지금 뭐 먹지?" type="now" />
-
-        <TopicContainer
-          title="🎉 새로 나왔어요"
-          type="new"
-          onFinished={() => {
-            restoreScroll('/home', $sel('.slide-page'))
-          }}
-        />
-
+        <LazyLoader>
+          <TopicContainer
+            title="🎉 새로 나왔어요"
+            type="new"
+            onFinished={() => {
+              restoreScroll('/home', $sel('.slide-page'))
+            }}
+          />
+        </LazyLoader>
         <div className="version">
           <a
             href="https://github.com/woowa-techcamp-2020/bmart-1"

--- a/src/pages/Bmart/Me/index.tsx
+++ b/src/pages/Bmart/Me/index.tsx
@@ -1,26 +1,61 @@
 import { User } from '@prisma/client'
+import $ from 'classnames'
 import React, { useEffect, useState } from 'react'
 import { useHistory } from 'react-router-dom'
 import { getUser } from 'src/apis'
 import ChevronRightIcon from 'src/components/icons/ChevronRightIcon'
-import { $$sel } from 'src/utils'
 import { useSigned } from 'src/utils/hooks'
-import { restoreScroll } from 'src/utils/scroll-manager'
 import './style.scss'
 
 export type MeProps = unknown
 
+const SignInButton: React.FC = () => {
+  return (
+    <div className="signed-out">
+      <a href="/auth/login">
+        <svg
+          width="34"
+          height="34"
+          viewBox="0 0 34 34"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          className="github"
+        >
+          <g clipPath="url(#clip0)">
+            <path
+              d="M17.2058 0.00622559C7.9814 0.00622559 0.5 7.48624 0.5 16.712C0.5 24.0932 5.2862 30.355 11.9254 32.5644C12.7593 32.7189 13.0293 32.201 13.0293 31.7611V28.6511C8.38234 29.6618 7.4148 26.6798 7.4148 26.6798C6.65469 24.7489 5.55906 24.2352 5.55906 24.2352C4.04302 23.198 5.67461 23.2203 5.67461 23.2203C7.35215 23.3372 8.23477 24.9424 8.23477 24.9424C9.72437 27.4956 12.1425 26.7577 13.0962 26.3303C13.2451 25.2514 13.6781 24.5136 14.157 24.0973C10.4469 23.6727 6.5461 22.2402 6.5461 15.8405C6.5461 14.0154 7.19901 12.5258 8.26679 11.3564C8.09417 10.9346 7.52199 9.23477 8.42967 6.93494C8.42967 6.93494 9.83296 6.48667 13.0252 8.64729C14.3574 8.27697 15.7858 8.09182 17.2058 8.08486C18.6258 8.09182 20.0555 8.27697 21.3906 8.64729C24.58 6.48667 25.9805 6.93494 25.9805 6.93494C26.8896 9.23617 26.3174 10.936 26.1448 11.3564C27.2167 12.5258 27.8641 14.0168 27.8641 15.8405C27.8641 22.2569 23.9563 23.67 20.2365 24.0834C20.8351 24.6013 21.3822 25.6176 21.3822 27.1768V31.7611C21.3822 32.2052 21.6495 32.7273 22.4973 32.563C29.1309 30.3509 33.9115 24.0904 33.9115 16.712C33.9115 7.48624 26.4315 0.00622559 17.2058 0.00622559Z"
+              fill="var(--distinct)"
+            />
+          </g>
+          <defs>
+            <clipPath id="clip0">
+              <rect
+                width="33.4115"
+                height="33.4115"
+                fill="white"
+                transform="translate(0.5 0.00622559)"
+              />
+            </clipPath>
+          </defs>
+        </svg>
+        GitHub으로 로그인
+      </a>
+    </div>
+  )
+}
+
 const Me: React.FC<MeProps> = () => {
   const { isSigned, signOut } = useSigned()
   const [user, setUser] = useState<User>(null)
+  const [isLoading, setLoading] = useState(true)
   const history = useHistory()
 
   async function loadUser() {
     const user = await getUser()
 
     setUser(user)
-
-    restoreScroll(window.location.pathname, $$sel('.slide-page')[2])
+    setLoading(false)
+    // restoreScroll(window.location.pathname, $$sel('.slide-page')[2])
   }
 
   useEffect(() => {
@@ -35,70 +70,59 @@ const Me: React.FC<MeProps> = () => {
 
   return (
     <div className="me">
-      {isSigned && !user ? (
-        <></>
-      ) : user ? (
-        <div className="signed-in">
-          <img src={user.profileImg} className="profile-image" alt="profile" />
-          <div className="user-info">
-            <p className="opening-ment">좋은 하루 되세요,</p>
-            <h1 className="user-name">{user.name}님</h1>
-          </div>
-          <ol className="menus">
-            <li className="address" onClick={() => history.push('/addresses')}>
-              <div className="icon address" />
-              <div className="title">배송지 설정</div>
-              <ChevronRightIcon width="8px" color="#808080" />
-            </li>
-            <li className="jjim" onClick={() => history.push('/jjims')}>
-              <div className="icon jjim" />
-              <div className="title">내가 찜한 상품</div>
-              <ChevronRightIcon width="8px" color="#808080" />
-            </li>
-            <li className="cart" onClick={() => history.push('/cart')}>
-              <div className="icon cart" />
-              <div className="title">장바구니</div>
-              <ChevronRightIcon width="8px" color="#808080" />
-            </li>
-          </ol>
-          <button className="sign-out" onClick={() => signOut()}>
-            로그아웃 하시게요?{' '}
-            <span role="img" aria-label="sad face">
-              😢
-            </span>
-          </button>
-        </div>
+      {!isSigned ? (
+        <SignInButton></SignInButton>
       ) : (
-        <div className="signed-out">
-          <a href="/auth/login">
-            <svg
-              width="34"
-              height="34"
-              viewBox="0 0 34 34"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              className="github"
-            >
-              <g clipPath="url(#clip0)">
-                <path
-                  d="M17.2058 0.00622559C7.9814 0.00622559 0.5 7.48624 0.5 16.712C0.5 24.0932 5.2862 30.355 11.9254 32.5644C12.7593 32.7189 13.0293 32.201 13.0293 31.7611V28.6511C8.38234 29.6618 7.4148 26.6798 7.4148 26.6798C6.65469 24.7489 5.55906 24.2352 5.55906 24.2352C4.04302 23.198 5.67461 23.2203 5.67461 23.2203C7.35215 23.3372 8.23477 24.9424 8.23477 24.9424C9.72437 27.4956 12.1425 26.7577 13.0962 26.3303C13.2451 25.2514 13.6781 24.5136 14.157 24.0973C10.4469 23.6727 6.5461 22.2402 6.5461 15.8405C6.5461 14.0154 7.19901 12.5258 8.26679 11.3564C8.09417 10.9346 7.52199 9.23477 8.42967 6.93494C8.42967 6.93494 9.83296 6.48667 13.0252 8.64729C14.3574 8.27697 15.7858 8.09182 17.2058 8.08486C18.6258 8.09182 20.0555 8.27697 21.3906 8.64729C24.58 6.48667 25.9805 6.93494 25.9805 6.93494C26.8896 9.23617 26.3174 10.936 26.1448 11.3564C27.2167 12.5258 27.8641 14.0168 27.8641 15.8405C27.8641 22.2569 23.9563 23.67 20.2365 24.0834C20.8351 24.6013 21.3822 25.6176 21.3822 27.1768V31.7611C21.3822 32.2052 21.6495 32.7273 22.4973 32.563C29.1309 30.3509 33.9115 24.0904 33.9115 16.712C33.9115 7.48624 26.4315 0.00622559 17.2058 0.00622559Z"
-                  fill="var(--distinct)"
-                />
-              </g>
-              <defs>
-                <clipPath id="clip0">
-                  <rect
-                    width="33.4115"
-                    height="33.4115"
-                    fill="white"
-                    transform="translate(0.5 0.00622559)"
-                  />
-                </clipPath>
-              </defs>
-            </svg>
-            GitHub으로 로그인
-          </a>
-        </div>
+        <>
+          <div className={$(['signed-in', { disabled: isLoading }])}>
+            {isLoading ? (
+              <div className="profile-image-fake"></div>
+            ) : (
+              <img
+                src={user.profileImg}
+                className="profile-image"
+                alt="profile"
+              />
+            )}
+            <div className="user-info">
+              <p className="opening-ment">좋은 하루 되세요,</p>
+              <h1 className="user-name">
+                {isLoading ? (
+                  <span className="mock">김철수닝오잉앙</span>
+                ) : (
+                  user.name
+                )}
+                님
+              </h1>
+            </div>
+            <ol className="menus">
+              <li
+                className="address"
+                onClick={() => history.push('/addresses')}
+              >
+                <div className="icon address" />
+                <div className="title">배송지 설정</div>
+                <ChevronRightIcon width="8px" color="#808080" />
+              </li>
+              <li className="jjim" onClick={() => history.push('/jjims')}>
+                <div className="icon jjim" />
+                <div className="title">내가 찜한 상품</div>
+                <ChevronRightIcon width="8px" color="#808080" />
+              </li>
+              <li className="cart" onClick={() => history.push('/cart')}>
+                <div className="icon cart" />
+                <div className="title">장바구니</div>
+                <ChevronRightIcon width="8px" color="#808080" />
+              </li>
+            </ol>
+            <button className="sign-out" onClick={() => signOut()}>
+              로그아웃 하시게요?{' '}
+              <span role="img" aria-label="sad face">
+                😢
+              </span>
+            </button>
+          </div>
+        </>
       )}
     </div>
   )

--- a/src/pages/Bmart/Me/style.scss
+++ b/src/pages/Bmart/Me/style.scss
@@ -6,12 +6,38 @@
   margin: auto;
   text-align: center;
 
+  .mock {
+    font-size: 20px;
+    border-radius: 7px;
+    height: 1.2em;
+    line-height: 140%;
+    background-color: #bbb;
+    color: #bbb;
+    margin-right: 0.7rem;
+  }
+
   .signed-in {
+    &.disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+
     .profile-image {
       width: 100%;
       max-width: 400px;
+      height: auto;
       margin: auto;
       border-radius: 20px;
+    }
+
+    .profile-image-fake {
+      display: inline-block;
+      width: 100%;
+      min-height: 335px;
+      max-width: 400px;
+      margin: auto;
+      border-radius: 20px;
+      background-color: #bbb;
     }
 
     .user-info {

--- a/src/pages/Bmart/Sale/index.tsx
+++ b/src/pages/Bmart/Sale/index.tsx
@@ -69,29 +69,6 @@ const Sale: React.FC<SaleProps> = () => {
   const lightningSentinelRef = useRef<HTMLDivElement>()
   const [saleProducts, setSaleProducts] = useState<ProductWithJjimmed[]>([])
 
-  async function getSaleProducts() {
-    const allProducts = (
-      await Promise.all(
-        DEFAULTS.CATEGORIES.map((category) =>
-          request(
-            `/products-by-category${createQuery({
-              category: category,
-              sortBy: 'discount',
-              direction: 'desc',
-              amount: '1',
-              page: '1',
-            })}`,
-            'GET'
-          )
-        )
-      )
-    ).flat()
-
-    setSaleProducts((prev) => [...prev, ...allProducts])
-  }
-
-  useLazy(getSaleProducts)
-
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
       for (const entry of entries) {

--- a/src/pages/Bmart/Sale/index.tsx
+++ b/src/pages/Bmart/Sale/index.tsx
@@ -5,7 +5,7 @@ import ProductItem from 'src/components/ProductItem'
 import { DEFAULTS } from 'src/constants'
 import { ProductWithJjimmed } from 'src/types/api'
 import { $sel } from 'src/utils'
-import { useLazy } from 'src/utils/hooks'
+import { useLazy, useSigned } from 'src/utils/hooks'
 import './style.scss'
 
 const timeouts: number[] = []
@@ -68,6 +68,7 @@ export type SaleProps = unknown
 const Sale: React.FC<SaleProps> = () => {
   const lightningSentinelRef = useRef<HTMLDivElement>()
   const [saleProducts, setSaleProducts] = useState<ProductWithJjimmed[]>([])
+  const { isSigned } = useSigned()
 
   useEffect(() => {
     const observer = new IntersectionObserver((entries) => {
@@ -107,7 +108,8 @@ const Sale: React.FC<SaleProps> = () => {
       )
     ).flat()
 
-    setSaleProducts((prev) => [...prev, ...allProducts])
+    // setSaleProducts((prev) => [...prev, ...allProducts])
+    setSaleProducts(allProducts)
     // restoreScroll(
     //   window.location.pathname,
     //   salePage.current?.closest('.slide-page')
@@ -115,6 +117,11 @@ const Sale: React.FC<SaleProps> = () => {
   }
 
   useLazy(init)
+
+  useEffect(() => {
+    setSaleProducts([])
+    init()
+  }, [isSigned])
 
   return (
     <div className="sale-page" ref={salePage}>

--- a/src/pages/Bmart/Sale/index.tsx
+++ b/src/pages/Bmart/Sale/index.tsx
@@ -5,8 +5,8 @@ import ProductItem from 'src/components/ProductItem'
 import { DEFAULTS } from 'src/constants'
 import { ProductWithJjimmed } from 'src/types/api'
 import { $sel } from 'src/utils'
-import { restoreScroll } from 'src/utils/scroll-manager'
 import { useLazy } from 'src/utils/hooks'
+import { restoreScroll } from 'src/utils/scroll-manager'
 import './style.scss'
 
 const timeouts: number[] = []
@@ -90,34 +90,32 @@ const Sale: React.FC<SaleProps> = () => {
 
   const salePage = useRef<HTMLDivElement>()
 
-  // useEffect(() => {
-  //   async function init() {
-  //     const allProducts = (
-  //       await Promise.all(
-  //         DEFAULTS.CATEGORIES.map((category) =>
-  //           request(
-  //             `/products-by-category${createQuery({
-  //               category: category,
-  //               sortBy: 'discount',
-  //               direction: 'desc',
-  //               amount: '1',
-  //               page: '1',
-  //             })}`,
-  //             'GET'
-  //           )
-  //         )
-  //       )
-  //     ).flat()
+  async function init() {
+    const allProducts = (
+      await Promise.all(
+        DEFAULTS.CATEGORIES.map((category) =>
+          request(
+            `/products-by-category${createQuery({
+              category: category,
+              sortBy: 'discount',
+              direction: 'desc',
+              amount: '1',
+              page: '1',
+            })}`,
+            'GET'
+          )
+        )
+      )
+    ).flat()
 
-  //     setSaleProducts((prev) => [...prev, ...allProducts])
-  //     restoreScroll(
-  //       window.location.pathname,
-  //       salePage.current.closest('.slide-page')
-  //     )
-  //   }
+    setSaleProducts((prev) => [...prev, ...allProducts])
+    restoreScroll(
+      window.location.pathname,
+      salePage.current.closest('.slide-page')
+    )
+  }
 
-  //   init()
-  // }, [])
+  useLazy(init)
 
   return (
     <div className="sale-page" ref={salePage}>

--- a/src/pages/Bmart/Sale/index.tsx
+++ b/src/pages/Bmart/Sale/index.tsx
@@ -6,7 +6,6 @@ import { DEFAULTS } from 'src/constants'
 import { ProductWithJjimmed } from 'src/types/api'
 import { $sel } from 'src/utils'
 import { useLazy } from 'src/utils/hooks'
-import { restoreScroll } from 'src/utils/scroll-manager'
 import './style.scss'
 
 const timeouts: number[] = []
@@ -109,10 +108,10 @@ const Sale: React.FC<SaleProps> = () => {
     ).flat()
 
     setSaleProducts((prev) => [...prev, ...allProducts])
-    restoreScroll(
-      window.location.pathname,
-      salePage.current.closest('.slide-page')
-    )
+    // restoreScroll(
+    //   window.location.pathname,
+    //   salePage.current?.closest('.slide-page')
+    // )
   }
 
   useLazy(init)

--- a/src/pages/Bmart/index.tsx
+++ b/src/pages/Bmart/index.tsx
@@ -328,7 +328,9 @@ const Bmart: React.FC<BmartProps> = ({ path }) => {
       <Header />
       <div className="slide-pages-scroll-wrapper" ref={slidePagesWrapper}>
         <SlidePage pageName="home">
-          <Home />
+          <LazyLoader>
+            <Home />
+          </LazyLoader>
         </SlidePage>
         <SlidePage pageName="sale">
           <LazyLoader>

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -23,11 +23,17 @@ function getTotalAmount(products: ProductsInCart) {
 const Cart: React.FC<CartProps> = (props) => {
   const [productsInCart, setProductsInCart] = useState<ProductInCart[]>([])
   const [totalAmount, setTotalAmount] = useState(0)
+  const [isEmpty, setEmpty] = useState(false)
 
   async function loadProductsInCart() {
     const productsInCart = (await getProductsInCart()) as ProductInCart[]
 
     setProductsInCart(productsInCart)
+
+    if (productsInCart.length == 0) {
+      setEmpty(true)
+    }
+
     setTotalAmount(getTotalAmount(productsInCart))
   }
 
@@ -39,7 +45,7 @@ const Cart: React.FC<CartProps> = (props) => {
     <div className="cart">
       <GoBack />
       <PageHeader Icon={ResizableCartIcon} title="장바구니"></PageHeader>
-      {productsInCart.length > 0 ? (
+      {!isEmpty ? (
         <>
           <div className="cart-items">
             {productsInCart.map((product) => (

--- a/src/pages/Cart/index.tsx
+++ b/src/pages/Cart/index.tsx
@@ -1,3 +1,4 @@
+import $ from 'classnames'
 import React, { useEffect, useState } from 'react'
 import { getProductsInCart } from 'src/apis'
 import Empty from 'src/components/Empty'
@@ -24,10 +25,12 @@ const Cart: React.FC<CartProps> = (props) => {
   const [productsInCart, setProductsInCart] = useState<ProductInCart[]>([])
   const [totalAmount, setTotalAmount] = useState(0)
   const [isEmpty, setEmpty] = useState(false)
+  const [isLoading, setLoading] = useState(true)
 
   async function loadProductsInCart() {
     const productsInCart = (await getProductsInCart()) as ProductInCart[]
 
+    setLoading(false)
     setProductsInCart(productsInCart)
 
     if (productsInCart.length == 0) {
@@ -57,11 +60,16 @@ const Cart: React.FC<CartProps> = (props) => {
             ))}
           </div>
           <div className="cart-footer">
-            <div className="cart-footer-total-price">
-              {totalAmount.toLocaleString()}원
-            </div>
+            {!isLoading && (
+              <div className="cart-footer-total-price">
+                {totalAmount.toLocaleString()}원
+              </div>
+            )}
             <div
-              className="cart-footer-confirm-button"
+              className={$([
+                'cart-footer-confirm-button',
+                { disabled: isLoading },
+              ])}
               onClick={() => Dialog().alert('여기까지😉')}
             >
               결제하기

--- a/src/pages/Cart/style.scss
+++ b/src/pages/Cart/style.scss
@@ -5,6 +5,15 @@
   max-width: 800px;
   margin: auto;
 
+  .mock {
+    border-radius: 7px;
+    height: 0.8em;
+    line-height: 140%;
+    background-color: #aaa;
+    color: #aaa;
+    margin-right: 0.7em;
+  }
+
   &-items {
     padding: 0 var(--ordinary-space);
 
@@ -29,6 +38,11 @@
       font-weight: 600;
       text-align: center;
       color: #fff;
+
+      &.disabled {
+        opacity: 0.5;
+        pointer-events: none;
+      }
     }
   }
 }

--- a/src/utils/scroll-manager.ts
+++ b/src/utils/scroll-manager.ts
@@ -18,11 +18,11 @@ export const restoreScroll = (key: string, element: HTMLElement): void => {
   )
 
   if (memory.direction === 'top') {
-    element.scrollTo({
+    element?.scrollTo({
       top: memory.scrollPosition ?? 0,
     })
   } else if (memory.direction === 'left') {
-    element.scrollTo({
+    element?.scrollTo({
       left: memory.scrollPosition ?? 0,
     })
   }


### PR DESCRIPTION
### Drawer
- Item을 클릭하면 Drawer를 닫도록 했습니다.
- Drawer를 닫으려면 DrawerContext.closeDrawer()를 호출해야되는데..
- ProductContainer, ProductItem 에 onClick()을 props로 서로 이어주어서 해결했습니다.
- 풀 리퀘스트 쓰면서 든 생각이지만, onClick을 줄줄이 연결하는 것 보다는 ProductItem에서 context가 있을 때 그냥 closeDrawer실행시켜주고 없으면 아무것도 안했어도 될 거 같긴 한데... 이게 더 명시적이니까...

### Skeleton UI
- Addresses
- Me
- Cart
의 스켈레톤 UI를 추가하였습니다.

- 그외 짜잘한 에러 헨들링

### 로그인/로그아웃 시 데이터 새로 불러오기
- 어차피 Home의 TopicContainer는 lazy-loading되니까 굳이 자동으로 처리 안해도 오케이!
- Sale에서 isSigned가 바뀔때마다 init()이 다시 실행되도록만 수정하였습니다!